### PR TITLE
Support for high-resolution displays

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -189,18 +189,43 @@
    * @this GitGraph
    **/
   GitGraph.prototype.render = function () {
-    // Resize canvas
-    this.canvas.height = Math.abs(this.columnMax * this.template.branch.spacingY)
-      +  Math.abs(this.commitOffsetY)
-      + this.marginY * 2;
+    var backingStorePixelRatio;
+    var scalingFactor;
 
-    this.canvas.width = Math.abs(this.columnMax * this.template.branch.spacingX)
-      +  Math.abs(this.commitOffsetX)
-      + this.marginX * 2;
+    // Account for high-resolution displays
+    scalingFactor = 1;
+
+    if (window.devicePixelRatio) {
+      backingStorePixelRatio = this.context.webkitBackingStorePixelRatio ||
+        this.context.mozBackingStorePixelRatio ||
+        this.context.msBackingStorePixelRatio ||
+        this.context.oBackingStorePixelRatio ||
+        this.context.backingStorePixelRatio || 1;
+
+      scalingFactor *= window.devicePixelRatio / backingStorePixelRatio;
+    }
+
+    // Resize canvas
+    var unscaledResolution = {
+      x: Math.abs(this.columnMax * this.template.branch.spacingX)
+        +  Math.abs(this.commitOffsetX)
+        + this.marginX * 2,
+      y: Math.abs(this.columnMax * this.template.branch.spacingY)
+        +  Math.abs(this.commitOffsetY)
+        + this.marginY * 2
+    };
 
     if (this.template.commit.message.display) {
-      this.canvas.width += 800;
+      unscaledResolution.x += 800;
     }
+
+    this.canvas.style.width = unscaledResolution.x + "px";
+    this.canvas.style.height = unscaledResolution.y + "px";
+
+    this.canvas.width = unscaledResolution.x * scalingFactor;
+    this.canvas.height = unscaledResolution.y * scalingFactor;
+
+    this.context.scale(scalingFactor, scalingFactor);
 
     // Clear All
     this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);


### PR DESCRIPTION
## About this commit

This commit adds support for high-resolution displays so the HTML5 `canvas` is properly scaled and displayed in the proper resolution.
## Before

![before](https://cloud.githubusercontent.com/assets/1239874/4346786/996f0aa6-4115-11e4-9ac1-d9e22d70e4bc.png)
## After

![after](https://cloud.githubusercontent.com/assets/1239874/4346785/99660ea6-4115-11e4-8ee8-b00414249501.png)
## Test

Tested on:
- Current Safari, Chrome, and Firefox on OS&nbsp;X with a Retina display
- Mobile Safari on iOS

Please test on other devices if you want. :relaxed:
