### PR TITLE
Add more message display options

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -36,7 +36,7 @@
    *
    * @param {Object} options - GitGraph options
    * @param {String} [options.elementId = "gitGraph"] - Id of the canvas container
-   * @param {Template|String} [options.template] - Template of the graph
+   * @param {Template|String|Object} [options.template] - Template of the graph
    * @param {String} [options.author = "Sergio Flores <saxo-guy@epic.com>"] - Default author for commits
    * @param {String} [options.mode = (null|"compact")]  - Display mode
    * @param {HTMLElement} [options.canvas] - DOM canvas (ex: document.getElementById("id"))
@@ -51,10 +51,17 @@
     this.author = (typeof options.author === "string") ? options.author : "Sergio Flores <saxo-guy@epic.com>";
 
     // Template management
-    if ( typeof options.template === "string" ) {
-      options.template = this.newTemplate( options.template );
+    if ( (typeof options.template === "string")
+      || (typeof options.template === "object")) {
+      this.template = this.newTemplate( options.template );
     }
-    this.template = (options.template instanceof Template) ? options.template : this.newTemplate( "metro" );
+    else if (options.template instanceof Template) {
+      this.template = options.template;
+    }
+    else {
+      this.template = this.newTemplate( "metro" );
+    }
+
     this.mode = options.mode || null;
     if ( this.mode === "compact" ) {
       this.template.commit.message.display = false;
@@ -201,6 +208,13 @@
     return this;
   };
 
+  /**
+   * Create a new template
+   *
+   * @param {(String|Object)} options - The template name, or the template options
+   *
+   * @return {Template}
+   **/
   GitGraph.prototype.newTemplate = function ( options ) {
     if ( typeof options === "string" ) {
       return new Template().get( options );
@@ -968,4 +982,5 @@
 
   // Expose GitGraph object
   window.GitGraph = GitGraph;
+  window.GitGraphTemplate = Template;
 })();

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -702,6 +702,8 @@
    * @param {String} [options.message = "He doesn't like George Michael! Boooo!"] - Commit message
    * @param {String} [options.messageColor = options.color] - Specific message color
    * @param {Boolean} [options.messageDisplay = this.template.commit.message.display] - Commit message policy
+   * @param {Boolean} [options.messageAuthorDisplay = this.template.commit.message.displayAuthor] - Commit message author policy
+   * @param {Boolean} [options.messageHashDisplay = this.template.commit.message.displayHash] - Commit message hash policy
    * @param {String} [options.type = ("mergeCommit"|null)] - Type of commit
    *
    * @this Commit
@@ -725,7 +727,10 @@
     this.message = options.message || "He doesn't like George Michael! Boooo!";
     this.arrowDisplay = options.arrowDisplay;
     this.messageDisplay = booleanOptionOr(options.messageDisplay, this.template.commit.message.display);
+    this.messageAuthorDisplay = booleanOptionOr(options.messageAuthorDisplay, this.template.commit.message.displayAuthor);
+    this.messageHashDisplay = booleanOptionOr(options.messageHashDisplay, this.template.commit.message.displayHash);
     this.messageColor = options.messageColor || options.color;
+    this.messageFont = options.messageFont || this.template.commit.message.font;
     this.dotColor = options.dotColor || options.color;
     this.dotSize = options.dotSize || this.template.commit.dot.size;
     this.dotStrokeWidth = options.dotStrokeWidth || this.template.commit.dot.strokeWidth;
@@ -772,8 +777,15 @@
 
     // Message
     if ( this.messageDisplay ) {
-      var message = this.sha1 + " " + this.message + (this.author ? " - " + this.author : "");
-      this.context.font = this.template.commit.message.font;
+      var message = this.message;
+      if ( this.messageHashDisplay ) {
+        message = this.sha1 + " " + message;
+      }
+      if ( this.messageAuthorDisplay ) {
+        message = message + (this.author ? " - " + this.author : "");
+      }
+
+      this.context.font = this.messageFont;
       this.context.fillStyle = this.messageColor;
       this.context.fillText( message, (this.parent.columnMax + 1) * this.template.branch.spacingX, this.y + 3 );
     }
@@ -860,6 +872,8 @@
    * @param {Number} [options.commit.dot.strokeColor] - Commit dot stroke color
    * @param {String} [options.commit.message.color] - Commit message color
    * @param {Boolean} [options.commit.message.display] - Commit display policy
+   * @param {Boolean} [options.commit.message.displayAuthor] - Commit message author policy
+   * @param {Boolean} [options.commit.message.displayHash] - Commit message hash policy
    * @param {String} [options.commit.message.font = "normal 12pt Calibri"] - Commit message font
    *
    * @this Template
@@ -913,6 +927,8 @@
 
     this.commit.message = {};
     this.commit.message.display = booleanOptionOr(options.commit.message.display, true);
+    this.commit.message.displayAuthor = booleanOptionOr(options.commit.message.displayAuthor, true);
+    this.commit.message.displayHash = booleanOptionOr(options.commit.message.displayHash, true);
 
     // Only one color, if null message takes commit color (only message)
     this.commit.message.color = options.commit.message.color || null;

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -724,7 +724,7 @@
     this.sha1 = options.sha1 || (Math.random( 100 )).toString( 16 ).substring( 3, 10 );
     this.message = options.message || "He doesn't like George Michael! Boooo!";
     this.arrowDisplay = options.arrowDisplay;
-    this.messageDisplay = options.messageDisplay || this.template.commit.message.display;
+    this.messageDisplay = booleanOptionOr(options.messageDisplay, this.template.commit.message.display);
     this.messageColor = options.messageColor || options.color;
     this.dotColor = options.dotColor || options.color;
     this.dotSize = options.dotSize || this.template.commit.dot.size;
@@ -912,7 +912,7 @@
     this.commit.dot.strokeColor = options.commit.dot.strokeColor || null;
 
     this.commit.message = {};
-    this.commit.message.display = (typeof options.commit.message.display === "boolean") ? options.commit.message.display : true;
+    this.commit.message.display = booleanOptionOr(options.commit.message.display, true);
 
     // Only one color, if null message takes commit color (only message)
     this.commit.message.color = options.commit.message.color || null;
@@ -979,6 +979,14 @@
 
     return new Template( template );
   };
+
+  // --------------------------------------------------------------------
+  // -----------------------      Utilities       -----------------------
+  // --------------------------------------------------------------------
+
+  function booleanOptionOr(booleanOption, defaultOption){
+    return (typeof booleanOption === "boolean") ? booleanOption : defaultOption;
+  }
 
   // Expose GitGraph object
   window.GitGraph = GitGraph;


### PR DESCRIPTION
Message display is now more fine grained. One can now:

- show/hide the commit hash globally or on a single commit
- show/hide the commit author globally or on a single commit