### PR TITLE
Replace link to releases, use latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Project page: <http://gitgraphjs.com/>
 
 You have different options to start with the library:
 
-- [Download the latest release](https://github.com/nicoespeon/gitgraph.js/releases/tag/v0.3.0).
+- [Download the latest release](https://github.com/nicoespeon/gitgraph.js/releases/latest).
 - Clone the repo: `git clone git://github.com/nicoespeon/gitgraph.js.git`.
 - Install with [Bower](http://bower.io/): `bower install gitgraph.js`.
 


### PR DESCRIPTION
Replace with dynamic link to the latest release.

In order to make that work you have to [create a release on github](https://help.github.com/articles/creating-releases/). Currently, they are just tags.