### PR TITLE
Fix "Cannot set property offsetX of MouseEvent..." for non-Firefox browsers

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -305,11 +305,13 @@
     var isOut = true;
 
     // Fix firefox MouseEvent
-    event.offsetX = event.offsetX ? event.offsetX : event.layerX;
-    event.offsetY = event.offsetY ? event.offsetY : event.layerY;
-    event.x = event.x ? event.x : event.clientX;
-    event.y = event.y ? event.y : event.clientY;
-
+    if (typeof InstallTrigger !== 'undefined')/* == (is Firefox) */ { 
+      event.offsetX = event.offsetX ? event.offsetX : event.layerX;
+      event.offsetY = event.offsetY ? event.offsetY : event.layerY;
+      event.x = event.x ? event.x : event.clientX;
+      event.y = event.y ? event.y : event.clientY;
+    }
+    
     function showCommitTooltip () {
       self.tooltip.style.left = event.x + "px"; // TODO Scroll bug
       self.tooltip.style.top = event.y + "px";  // TODO Scroll bug


### PR DESCRIPTION
Fix the "Cannot set property offsetX of #<MouseEvent> which has only a getter" error for non-Firefox browsers.

Check that current browser is Firefox was taken from http://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser


