### PR TITLE
Reuse a deleted branch's column only once

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -674,7 +674,11 @@
       if ( !branch.isfinish ) {
         this.column++;
       } else {
-        break;
+        if ( !branch.isdead ) {
+          this.column = branch.column;
+          branch.isdead = true;
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
This should fix bug #49: Git Branches overlap when using .delete()

Signed-off-by: Jon Ringle <jringle@gridpoint.com>