### PR TITLE
Reuse a deleted branch's column only once

### DIFF
--- a/examples/gitflowsupport.html
+++ b/examples/gitflowsupport.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8">
     <title>git flow with support</title>
-    <link rel="stylesheet" type="text/css" href="css/gitgraph.css" />
+    <link rel="stylesheet" type="text/css" href="../src/gitgraph.css" />
     <style>
       body {
         margin: 0;

--- a/examples/gitflowsupport.html
+++ b/examples/gitflowsupport.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html lang="en">
+  
+  <head>
+    <meta charset="UTF-8">
+    <title>git flow with support</title>
+    <link rel="stylesheet" type="text/css" href="css/gitgraph.css" />
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  
+  <body>
+    <canvas id="gitGraph"></canvas>
+    <div id="detail" class="gitgraph-detail">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sint, ducimus, qui fuga corporis veritatis doloribus iure nulla optio dolores maiores dolorum ullam alias cum libero obcaecati cupiditate sit illo aperiam possimus voluptatum similique neque explicabo quibusdam aspernatur dolorem. Quod, corrupti magni explicabo nam sequi nesciunt accusamus aliquam dolore! Cumque, quam fugiat ab veritatis. Quia, maxime quas perferendis cupiditate explicabo at atque iusto accusamus. Nesciunt veniam quidem nemo doloribus! Dolore, cupiditate, adipisci, voluptate quam nihil ipsa placeat dolor possimus minus quas nostrum eaque in dicta autem eligendi rerum facilis nesciunt sunt doloremque suscipit enim iure vitae eius voluptates tempora tenetur hic.</div>
+    <script src="js/gitgraph.js"></script>
+    <script src="gitflowsupport.js"></script>
+  </body>
+
+</html>

--- a/examples/gitflowsupport.js
+++ b/examples/gitflowsupport.js
@@ -2,21 +2,27 @@ var graphConfig = new GitGraph.Template({
     branch: {
         color: "#000000",
         lineWidth: 3,
-        spacingX: 50,
-        mergeStyle: "straight"
+        spacingX: 60,
+        mergeStyle: "straight",
+        showLabel: true,
+        labelFont: "normal 10pt Arial"
     },
     commit: {
         spacingY: -30,
         dot: {
-            size: 6,
+            size: 8,
             strokeColor: "#000000",
             strokeWidth: 4
         },
+        tag: {
+            font: "normal 10pt Arial",
+            color: "yellow"
+        },
         message: {
             color: "black",
-            font: "normal 14pt Arial",
+            font: "normal 12pt Arial",
             displayAuthor: false,
-            displayBranch: true,
+            displayBranch: false,
             displayHash: false,
         }
     },
@@ -56,7 +62,7 @@ var gitgraph = new GitGraph(config);
 
 var master = gitgraph.branch({name:"master", column:masterCol});
 var develop = gitgraph.branch({parentBranch:master, name: "develop", column:developCol});
-master.commit(" ").merge(develop, " ");
+master.commit({messageDisplay:false}).merge(develop, {messageDisplay:false});
 develop.commit({messageDisplay:false});
 
 var feature1 = gitgraph.branch({parentBranch:develop, name:"feature/1", column:featureCol});
@@ -68,35 +74,35 @@ feature2.commit("Another feature to go into v1.0.0").commit({messageDisplay:fals
 feature2.merge(develop);
 
 var release_100 = gitgraph.branch({parentBranch: develop, name: "release/v1.0.0", column:releaseCol});
-release_100.commit({message:"Start v1.0.0-rc Release Candidate builds",marker:"v1.0.0-rc",markerColor:'cyan'});
+release_100.commit({message:"Start v1.0.0-rc Release Candidate builds",tag:"v1.0.0-rc",tagColor:'gray'});
 develop.commit({messageDisplay:false});
 release_100.commit(stablizationCommit);
-release_100.merge(develop).merge(master, {dotStrokeWidth: 10, message: "Release v1.0.0 tagged",marker:"v1.0.0"});
+release_100.merge(develop).merge(master, {dotStrokeWidth: 10, message: "Release v1.0.0 tagged",tag:"v1.0.0"});
 
 var support_10x = gitgraph.branch({parentBranch: master, name: "support/v1.0.x", column:supportCol});
-support_10x.commit({message:"Start v1.0.1-rc Release Candidate builds",marker:"v1.0.1-rc",markerColor:'cyan'}).commit(bugfixCommit);
+support_10x.commit({message:"Start v1.0.1-rc Release Candidate builds",tag:"v1.0.1-rc",tagColor:'gray'}).commit(bugfixCommit);
 
 var feature3 = gitgraph.branch({parentBranch:develop, name:"feature/3", column:featureCol});
 develop.commit({messageDisplay:false});
 feature3.commit("A feature to go into v1.1.0").commit({messageDisplay:false});
 feature3.merge(develop);
 
-support_10x.commit({dotStrokeWidth: 10, message: "Release v1.0.1 tagged",marker:"v1.0.1"}).merge(develop);
+support_10x.commit({dotStrokeWidth: 10, message: "Release v1.0.1 tagged",tag:"v1.0.1"}).merge(develop);
 
 develop.commit({messageDisplay:false});
-support_10x.commit({message:"Start v1.0.2-rc Release Candidate builds",marker:"v1.0.2-rc",markerColor:'cyan'})
-support_10x.commit(bugfixCommit).commit({dotStrokeWidth: 10, message: "Release v1.0.2 tagged",marker:'v1.0.2'});
+support_10x.commit({message:"Start v1.0.2-rc Release Candidate builds",tag:"v1.0.2-rc",tagColor:'gray'})
+support_10x.commit(bugfixCommit).commit({dotStrokeWidth: 10, message: "Release v1.0.2 tagged",tag:'v1.0.2'});
 support_10x.merge(develop);
 develop.commit({messageDisplay:false});
 
 var release_110 = gitgraph.branch({parentBranch: develop, name: "release/v1.1.0", column:releaseCol});
-release_110.commit({message:"Start v1.1.0-rc Release Candidate builds",marker:"v1.1.0-rc",markerColor:'cyan'})
+release_110.commit({message:"Start v1.1.0-rc Release Candidate builds",tag:"v1.1.0-rc",tagColor:'gray'})
 release_110.commit(stablizationCommit);
-release_110.merge(develop).merge(master, {dotStrokeWidth: 10, message: "Release v1.1.0 tagged",marker:"v1.1.0"});
+release_110.merge(develop).merge(master, {dotStrokeWidth: 10, message: "Release v1.1.0 tagged",tag:"v1.1.0"});
 
 var support_11x = gitgraph.branch({parentBranch: master, name: "support/v1.1.x", column:supportCol});
-support_11x.commit({message:"Start v1.1.1-rc Release Candidate builds",marker:"v1.1.1-rc",markerColor:'cyan'})
-support_11x.commit(bugfixCommit).commit({dotStrokeWidth: 10, message: "Release v1.1.1 tagged",marker:"v1.1.1"});
+support_11x.commit({message:"Start v1.1.1-rc Release Candidate builds",tag:"v1.1.1-rc",tagColor:'gray'})
+support_11x.commit(bugfixCommit).commit({dotStrokeWidth: 10, message: "Release v1.1.1 tagged",tag:"v1.1.1"});
 support_11x.merge(develop);
 develop.commit({messageDisplay:false});
 
@@ -105,8 +111,8 @@ develop.commit({messageDisplay:false});
 feature4.commit("A feature to go into v1.2.0").commit({messageDisplay:false});
 feature4.merge(develop);
 
-support_11x.commit({message:"Start v1.1.2-rc Release Candidate builds",marker:"v1.1.2-rc",markerColor:'cyan'})
-support_11x.commit(bugfixCommit).commit({dotStrokeWidth: 10, message: "Release v1.1.2",marker:"v1.1.2"});
+support_11x.commit({message:"Start v1.1.2-rc Release Candidate builds",tag:"v1.1.2-rc",tagColor:'gray'})
+support_11x.commit(bugfixCommit).commit({dotStrokeWidth: 10, message: "Release v1.1.2",tag:"v1.1.2"});
 support_11x.merge(develop);
 develop.commit({messageDisplay:false});
 
@@ -115,13 +121,13 @@ develop.commit({messageDisplay:false});
 feature5.commit("Another feature to go into v1.2.0").commit({messageDisplay:false});
 feature5.merge(develop);
 
-support_11x.commit({message:"Start v1.1.3-rc Release Candidate builds",marker:"v1.1.3-rc",markerColor:'cyan'})
-support_11x.commit(bugfixCommit).commit({dotStrokeWidth: 10, message: "Release v1.1.3 tagged",marker:"v1.1.3"});
+support_11x.commit({message:"Start v1.1.3-rc Release Candidate builds",tag:"v1.1.3-rc",tagColor:'gray'})
+support_11x.commit(bugfixCommit).commit({dotStrokeWidth: 10, message: "Release v1.1.3 tagged",tag:"v1.1.3"});
 support_11x.merge(develop);
 develop.commit({messageDisplay:false});
 
 var release_120 = gitgraph.branch({parentBranch: develop, name: "release/v1.2.0", column:releaseCol});
-release_120.commit({message:"Start v1.2.0-rc Release Candidate builds",marker:"v1.2.0-rc",markerColor:'cyan'})
+release_120.commit({message:"Start v1.2.0-rc Release Candidate builds",tag:"v1.2.0-rc",tagColor:'gray'})
 release_120.commit(stablizationCommit);
-release_120.merge(develop).merge(master, {dotStrokeWidth: 10, message: "Release v1.2.0 tagged",marker:"v1.2.0"});
+release_120.merge(develop).merge(master, {dotStrokeWidth: 10, message: "Release v1.2.0 tagged",tag:"v1.2.0"});
 develop.commit({messageDisplay:false});

--- a/examples/gitflowsupport.js
+++ b/examples/gitflowsupport.js
@@ -1,0 +1,127 @@
+var graphConfig = new GitGraph.Template({
+    branch: {
+        color: "#000000",
+        lineWidth: 3,
+        spacingX: 50,
+        mergeStyle: "straight"
+    },
+    commit: {
+        spacingY: -30,
+        dot: {
+            size: 6,
+            strokeColor: "#000000",
+            strokeWidth: 4
+        },
+        message: {
+            color: "black",
+            font: "normal 14pt Arial",
+            displayAuthor: false,
+            displayBranch: true,
+            displayHash: false,
+        }
+    },
+    arrow: {
+        size: 8,
+        offset: 3
+    }
+});
+
+var config = {
+  template: graphConfig,
+  mode: "extended",
+  orientation: "vertical"
+};
+
+var bugfixCommit = {
+  messageAuthorDisplay:false,
+  messageBranchDisplay:false,
+  messageHashDisplay:false,
+  message:"Bug fix commit(s)"
+};
+
+var stablizationCommit = {
+  messageAuthorDisplay:false,
+  messageBranchDisplay:false,
+  messageHashDisplay:false,
+  message:"Release stablization commit(s)"
+};
+
+var featureCol = 0;
+var developCol = 1;
+var releaseCol = 2;
+var supportCol = 3;
+var masterCol = 4;
+
+var gitgraph = new GitGraph(config);
+
+var master = gitgraph.branch({name:"master", column:masterCol});
+var develop = gitgraph.branch({parentBranch:master, name: "develop", column:developCol});
+master.commit(" ").merge(develop, " ");
+develop.commit({messageDisplay:false});
+
+var feature1 = gitgraph.branch({parentBranch:develop, name:"feature/1", column:featureCol});
+feature1.commit("A feature to go into v1.0.0").commit({messageDisplay:false});
+feature1.merge(develop);
+
+var feature2 = gitgraph.branch({parentBranch:develop, name:"feature/2", column:featureCol});
+feature2.commit("Another feature to go into v1.0.0").commit({messageDisplay:false});
+feature2.merge(develop);
+
+var release_100 = gitgraph.branch({parentBranch: develop, name: "release/v1.0.0", column:releaseCol});
+release_100.commit({message:"Start v1.0.0-rc Release Candidate builds",marker:"v1.0.0-rc",markerColor:'cyan'});
+develop.commit({messageDisplay:false});
+release_100.commit(stablizationCommit);
+release_100.merge(develop).merge(master, {dotStrokeWidth: 10, message: "Release v1.0.0 tagged",marker:"v1.0.0"});
+
+var support_10x = gitgraph.branch({parentBranch: master, name: "support/v1.0.x", column:supportCol});
+support_10x.commit({message:"Start v1.0.1-rc Release Candidate builds",marker:"v1.0.1-rc",markerColor:'cyan'}).commit(bugfixCommit);
+
+var feature3 = gitgraph.branch({parentBranch:develop, name:"feature/3", column:featureCol});
+develop.commit({messageDisplay:false});
+feature3.commit("A feature to go into v1.1.0").commit({messageDisplay:false});
+feature3.merge(develop);
+
+support_10x.commit({dotStrokeWidth: 10, message: "Release v1.0.1 tagged",marker:"v1.0.1"}).merge(develop);
+
+develop.commit({messageDisplay:false});
+support_10x.commit({message:"Start v1.0.2-rc Release Candidate builds",marker:"v1.0.2-rc",markerColor:'cyan'})
+support_10x.commit(bugfixCommit).commit({dotStrokeWidth: 10, message: "Release v1.0.2 tagged",marker:'v1.0.2'});
+support_10x.merge(develop);
+develop.commit({messageDisplay:false});
+
+var release_110 = gitgraph.branch({parentBranch: develop, name: "release/v1.1.0", column:releaseCol});
+release_110.commit({message:"Start v1.1.0-rc Release Candidate builds",marker:"v1.1.0-rc",markerColor:'cyan'})
+release_110.commit(stablizationCommit);
+release_110.merge(develop).merge(master, {dotStrokeWidth: 10, message: "Release v1.1.0 tagged",marker:"v1.1.0"});
+
+var support_11x = gitgraph.branch({parentBranch: master, name: "support/v1.1.x", column:supportCol});
+support_11x.commit({message:"Start v1.1.1-rc Release Candidate builds",marker:"v1.1.1-rc",markerColor:'cyan'})
+support_11x.commit(bugfixCommit).commit({dotStrokeWidth: 10, message: "Release v1.1.1 tagged",marker:"v1.1.1"});
+support_11x.merge(develop);
+develop.commit({messageDisplay:false});
+
+var feature4 = gitgraph.branch({parentBranch:develop, name:"feature/4", column:featureCol});
+develop.commit({messageDisplay:false});
+feature4.commit("A feature to go into v1.2.0").commit({messageDisplay:false});
+feature4.merge(develop);
+
+support_11x.commit({message:"Start v1.1.2-rc Release Candidate builds",marker:"v1.1.2-rc",markerColor:'cyan'})
+support_11x.commit(bugfixCommit).commit({dotStrokeWidth: 10, message: "Release v1.1.2",marker:"v1.1.2"});
+support_11x.merge(develop);
+develop.commit({messageDisplay:false});
+
+var feature5 = gitgraph.branch({parentBranch:develop, name:"feature/5", column:featureCol});
+develop.commit({messageDisplay:false});
+feature5.commit("Another feature to go into v1.2.0").commit({messageDisplay:false});
+feature5.merge(develop);
+
+support_11x.commit({message:"Start v1.1.3-rc Release Candidate builds",marker:"v1.1.3-rc",markerColor:'cyan'})
+support_11x.commit(bugfixCommit).commit({dotStrokeWidth: 10, message: "Release v1.1.3 tagged",marker:"v1.1.3"});
+support_11x.merge(develop);
+develop.commit({messageDisplay:false});
+
+var release_120 = gitgraph.branch({parentBranch: develop, name: "release/v1.2.0", column:releaseCol});
+release_120.commit({message:"Start v1.2.0-rc Release Candidate builds",marker:"v1.2.0-rc",markerColor:'cyan'})
+release_120.commit(stablizationCommit);
+release_120.merge(develop).merge(master, {dotStrokeWidth: 10, message: "Release v1.2.0 tagged",marker:"v1.2.0"});
+develop.commit({messageDisplay:false});

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -101,6 +101,7 @@
     // Canvas init
     this.canvas = document.getElementById( this.elementId ) || options.canvas;
     this.context = this.canvas.getContext( "2d" );
+    this.context.textBaseline = 'bottom';
 
     // Tooltip layer
     this.tooltip = document.createElement( "div" );
@@ -738,6 +739,8 @@
     this.author = options.author || this.parent.author;
     this.date = options.date || new Date().toUTCString();
     this.detail = options.detail || null;
+    this.marker = options.marker || null;
+    this.markerColor = options.markerColor || 'yellow';
     this.sha1 = options.sha1 || (Math.random( 100 )).toString( 16 ).substring( 3, 10 );
     this.message = options.message || "He doesn't like George Michael! Boooo!";
     this.arrowDisplay = options.arrowDisplay;
@@ -791,6 +794,16 @@
       this.detail.width = 30;
     }
 
+    this.context.font = this.messageFont;
+
+    // Marker
+    var markerWidth = this.template.branch.spacingX;
+    if ( this.marker !== null ) {
+      drawTextBG( this.context, (this.parent.columnMax + 1) * this.template.branch.spacingX - (this.template.branch.spacingX/2), this.y + 3, this.marker, "black", this.markerColor );
+      var textWidth = this.context.measureText(this.marker).width;
+      markerWidth = (markerWidth < textWidth) ? textWidth : markerWidth;
+    }
+
     // Message
     if ( this.messageDisplay ) {
       var message = this.message;
@@ -804,9 +817,8 @@
         message = (this.branch.name ? "[" + this.branch.name + "] ": "") + message;
       }
 
-      this.context.font = this.messageFont;
       this.context.fillStyle = this.messageColor;
-      this.context.fillText( message, (this.parent.columnMax + 1) * this.template.branch.spacingX, this.y + 3 );
+      this.context.fillText( message, ((this.parent.columnMax + 1) * this.template.branch.spacingX) + markerWidth, this.y + 3 );
     }
   };
 
@@ -1025,6 +1037,24 @@
 
   function booleanOptionOr(booleanOption, defaultOption){
     return (typeof booleanOption === "boolean") ? booleanOption : defaultOption;
+  }
+
+  function drawTextBG( context, x, y, text, fgcolor, bgcolor ) {
+    context.save();
+    var width = context.measureText(text).width;
+    var height = parseInt(context.font, 10);
+
+    context.beginPath();
+    context.rect(x-2, y-height+2, width+4, height+2);
+    context.fillStyle = bgcolor;
+    context.fill();
+    context.lineWidth = 2;
+    context.strokeStyle = 'black';
+    context.stroke();
+
+    context.fillStyle = fgcolor;
+    context.fillText(text, x, y);
+    context.restore();
   }
 
   // Expose GitGraph object

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -975,6 +975,7 @@
     this.branch.showLabel = options.branch.showLabel || false;
     this.branch.labelColor = options.branch.labelColor || null;
     this.branch.labelFont = options.branch.labelFont || "normal 8pt Calibri";
+    this.branch.labelRotation = options.branch.labelRotation || 0;
 
     // Merge style = "bezier" | "straight"
     this.branch.mergeStyle = options.branch.mergeStyle || "bezier";

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -397,8 +397,14 @@
     this.path = []; // Path to draw, this is an array of points {x, y, type("start"|"join"|"end")}
 
     // Column number calculation for auto-color & auto-offset
-    this.column = 0;
-    this.calculColumn();
+    if ( typeof options.column === "number" ) {
+      this.column = options.column;
+    } else {
+      this.column = 0;
+      this.calculColumn();
+    }
+
+    this.parent.columnMax = (this.column > this.parent.columnMax) ? this.column : this.parent.columnMax;
 
     // Options with auto value
     this.offsetX = this.column * this.spacingX;
@@ -681,8 +687,6 @@
         }
       }
     }
-
-    this.parent.columnMax = (this.column > this.parent.columnMax) ? this.column : this.parent.columnMax;
   };
 
   // --------------------------------------------------------------------

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -715,9 +715,8 @@
     
     this.column = 0;
     for ( ; ; this.column++ ) {
-      if ( !( this.column in candidates ) || candidates[ this.column ] == 0 ) {
+      if ( !( this.column in candidates ) || candidates[ this.column ] === 0 ) {
           break;
-        }
       }
     }
   };

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -826,7 +826,7 @@
     var tagWidth = this.template.branch.spacingX;
     if ( this.tag !== null ) {
       drawTextBG( this.context, (this.parent.columnMax + 1) * this.template.branch.spacingX - (this.template.branch.spacingX/2), this.y + 3, this.tag, "black", this.tagColor, this.tagFont );
-      var textWidth = this.context.measureText(this.tag).width;
+      var textWidth = this.context.measureText(this.tag).width - (this.template.branch.spacingX/2);
       tagWidth = (tagWidth < textWidth) ? textWidth : tagWidth;
     }
 

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -515,7 +515,7 @@
       this.parent.commitOffsetY -= this.template.commit.spacingY;
     }
 
-    options.messageColor = options.messageColor || options.color || this.template.commit.message.color || null;
+    options.messageColor = options.messageColor || this.template.commit.message.color || options.color || null;
     options.dotColor = options.dotColor || options.color || this.template.commit.dot.color || null;
     options.x = this.offsetX - this.parent.commitOffsetX;
     options.y = this.offsetY - this.parent.commitOffsetY;

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -674,7 +674,11 @@
       if ( !branch.isfinish ) {
         this.column++;
       } else {
-        break;
+        if ( !branch.isdead ) {
+          this.column = branch.column;
+          branch.isdead = true;
+          break;
+        }
       }
     }
 

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -257,10 +257,10 @@
 
     // Resize canvas
     var unscaledResolution = {
-      x: Math.abs( this.columnMax * this.template.branch.spacingX )
+      x: Math.abs( (this.columnMax + 1 ) * this.template.branch.spacingX )
          + Math.abs( this.commitOffsetX )
          + this.marginX * 2,
-      y: Math.abs( this.columnMax * this.template.branch.spacingY )
+      y: Math.abs( (this.columnMax + 1 ) * this.template.branch.spacingY )
          + Math.abs( this.commitOffsetY )
          + this.marginY * 2
     };
@@ -297,6 +297,8 @@
     for ( var i = this.branchs.length - 1, branch; !!(branch = this.branchs[ i ]); i-- ) {
       branch.render();
     }
+
+    this.tagNum = 0;
 
     // Render commits after to put them on the foreground
     for ( var j = 0, commit; !!(commit = this.commits[ j ]); j++ ) {
@@ -833,12 +835,14 @@
     // Tag
     var tagWidth = this.template.commit.tag.spacingX;
     if ( this.tag !== null ) {
+      this.parent.tagNum++;
       var textWidth = this.context.measureText(this.tag).width;
       if ( this.template.branch.labelRotation !== 0 ) {
+        var textHeight = getFontHeight(this.tagFont);
         drawTextBG( this.context,
           this.x - this.dotSize/2,
-          ((this.parent.columnMax + 1) * this.template.commit.tag.spacingY) - this.template.commit.tag.spacingY/2,
-          this.tag, "red", this.tagColor, this.tagFont, 0 );
+          ((this.parent.columnMax + 1) * this.template.commit.tag.spacingY) - this.template.commit.tag.spacingY/2 + (this.parent.tagNum % 2) * textHeight * 1.5,
+          this.tag, "black", this.tagColor, this.tagFont, 0 );
       } else {
         drawTextBG( this.context,
           ((this.parent.columnMax + 1) * this.template.commit.tag.spacingX) - this.template.commit.tag.spacingX/2 + textWidth/2,
@@ -1090,12 +1094,12 @@
   // -----------------------      Utilities       -----------------------
   // --------------------------------------------------------------------
 
-  var getFontHeight = function(fontStyle) {
+  var getFontHeight = function(font) {
     var body = document.getElementsByTagName("body")[0];
     var dummy = document.createElement("div");
     var dummyText = document.createTextNode("Mg");
     dummy.appendChild(dummyText);
-    dummy.setAttribute("style", fontStyle);
+    dummy.setAttribute("style", "font: " + font + ";");
     body.appendChild(dummy);
     var result = dummy.offsetHeight;
     body.removeChild(dummy);
@@ -1114,7 +1118,7 @@
 
     context.font = font;
     var width = context.measureText(text).width;
-    var height = getFontHeight("font: " + font + ";");
+    var height = getFontHeight(font);
 
     context.beginPath();
     context.rect(-(width/2)-4, -(height/2)+2, width+8, height+2);

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -316,7 +316,7 @@
     var isOut = true;
 
     // Fix firefox MouseEvent
-    if (typeof InstallTrigger !== 'undefined')/* == (is Firefox) */ { 
+    if (typeof InstallTrigger !== "undefined")/* == (is Firefox) */ { 
       event.offsetX = event.offsetX ? event.offsetX : event.layerX;
       event.offsetY = event.offsetY ? event.offsetY : event.layerY;
       event.x = event.x ? event.x : event.clientX;
@@ -834,7 +834,7 @@
     var tagWidth = this.template.commit.tag.spacingX;
     if ( this.tag !== null ) {
       var textWidth = this.context.measureText(this.tag).width;
-      if ( this.template.branch.labelRotation != 0 ) {
+      if ( this.template.branch.labelRotation !== 0 ) {
         drawTextBG( this.context,
           this.x - this.dotSize/2,
           ((this.parent.columnMax + 1) * this.template.commit.tag.spacingY) - this.template.commit.tag.spacingY/2,
@@ -1109,7 +1109,7 @@
     context.save();
     context.translate(x, y);
     context.rotate(angle*(Math.PI/180));
-    context.textAlign = 'center';
+    context.textAlign = "center";
 
     context.font = font;
     var width = context.measureText(text).width;


### PR DESCRIPTION
This should fix bug #49: Git Branches overlap when using .delete()

Signed-off-by: Jon Ringle <jringle@gridpoint.com>