### PR TITLE
Fix the column calculation algorithm

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -670,10 +670,19 @@
    * @this Branch
    **/
   Branch.prototype.calculColumn = function () {
+    var candidates = [];
     for ( var i = 0, branch; !!(branch = this.parent.branchs[ i ]); i++ ) {
       if ( !branch.isfinish ) {
-        this.column++;
-      } else {
+        if ( !( branch.column in candidates ) ) {
+          candidates[ branch.column ] = 0;
+        }
+        candidates[ branch.column ]++;
+      }
+    }
+    
+    this.column = 0;
+    for ( ; ; this.column++ ) {
+      if ( !( this.column in candidates ) || candidates[ this.column ] == 0 ) {
         break;
       }
     }


### PR DESCRIPTION
After the first merge, the original algorithm will assign every new branch the same column, resulting in collisions. Fix to handle arbitrary numbers and orders of merges and branches.