### PR TITLE
Added the ability to assign 'onClick' events to commits. 

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -275,6 +275,8 @@
       unscaledResolution.x += 800;
     }
 
+    unscaledResolution.x += this.template.commit.widthExtension;
+
     this.canvas.style.width = unscaledResolution.x + "px";
     this.canvas.style.height = unscaledResolution.y + "px";
 
@@ -998,6 +1000,7 @@
    * @param {Number} [options.branch.spacingY] - Space between branchs
    * @param {Number} [options.commit.spacingX] - Space between commits
    * @param {Number} [options.commit.spacingY] - Space between commits
+   * @param {Number} [options.commit.widthExtension = 0]  - Additional width to be added to the calculated width
    * @param {String} [options.commit.color] - Master commit color (dot & message)
    * @param {String} [options.commit.dot.color] - Commit dot color
    * @param {Number} [options.commit.dot.size] - Commit dot size
@@ -1053,6 +1056,7 @@
     this.commit = {};
     this.commit.spacingX = options.commit.spacingX || 0;
     this.commit.spacingY = (typeof options.commit.spacingY === "number") ? options.commit.spacingY : 25;
+    this.commit.widthExtension = (typeof options.commit.widthExtension === "number") ? options.commit.widthExtension : 0;
 
     // Only one color, if null message takes branch color (full commit)
     this.commit.color = options.commit.color || null;

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -332,11 +332,12 @@
    **/
   GitGraph.prototype.applyCommits = function(event, callbackFn) {
     // Fix firefox MouseEvent
-    event.offsetX = event.offsetX ? event.offsetX : event.layerX;
-    event.offsetY = event.offsetY ? event.offsetY : event.layerY;
-    event.x = event.x ? event.x : event.clientX;
-    event.y = event.y ? event.y : event.clientY;
-
+    if ( typeof InstallTrigger !== "undefined" )/* == (is Firefox) */ {  
+      event.offsetX = event.offsetX ? event.offsetX : event.layerX;
+      event.offsetY = event.offsetY ? event.offsetY : event.layerY;
+      event.x = event.x ? event.x : event.clientX;
+      event.y = event.y ? event.y : event.clientY;
+    }
 
     for ( var i = 0, commit; !!(commit = this.commits[ i ]); i++ ) {
       var distanceX = (commit.x + this.offsetX + this.marginX - event.offsetX);
@@ -412,12 +413,10 @@
    * @self Gitgraph
    **/
   GitGraph.prototype.click = function ( event ) {
-    var self = this.gitgraph;
-    self.applyCommits(event, function(commit, isOverCommit) {
-      if (isOverCommit) {
-        if (!(commit.onClick === null)) {
-          commit.onClick(commit, true);
-        }
+    this.gitgraph.applyCommits(event, function(commit, isOverCommit) {
+      if (!isOverCommit) return;
+      if (!(commit.onClick === null)) {
+        commit.onClick(commit, true);
       }
     });
   };

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -362,7 +362,11 @@
     function showCommitTooltip (commit) {
       self.tooltip.style.left = event.x + "px"; // TODO Scroll bug
       self.tooltip.style.top = event.y + "px";  // TODO Scroll bug
-      self.tooltip.textContent = commit.sha1 + " - " + commit.message;
+      if (!(self.template.commit.tooltipHTMLFormatter === null)) {
+        self.tooltip.innerHTML = self.template.commit.tooltipHTMLFormatter(commit);
+      } else {
+        self.tooltip.textContent = commit.sha1 + " - " + commit.message;
+      }
       self.tooltip.style.display = "block";
     }
 
@@ -1012,6 +1016,7 @@
    * @param {Boolean} [options.commit.message.displayBranch] - Commit message branch policy
    * @param {Boolean} [options.commit.message.displayHash] - Commit message hash policy
    * @param {String} [options.commit.message.font = "normal 12pt Calibri"] - Commit message font
+   * @param {commitCallback} [options.commit.tooltipHTMLFormatter] - Formatter for the tooltip contents.
    *
    * @this Template
    **/
@@ -1057,6 +1062,7 @@
     this.commit.spacingX = options.commit.spacingX || 0;
     this.commit.spacingY = (typeof options.commit.spacingY === "number") ? options.commit.spacingY : 25;
     this.commit.widthExtension = (typeof options.commit.widthExtension === "number") ? options.commit.widthExtension : 0;
+    this.commit.tooltipHTMLFormatter = options.commit.tooltipHTMLFormatter || null;
 
     // Only one color, if null message takes branch color (full commit)
     this.commit.color = options.commit.color || null;

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -806,6 +806,7 @@
    * @param {Boolean} [options.messageHashDisplay = this.template.commit.message.displayHash] - Commit message hash policy
    * @param {String} [options.type = ("mergeCommit"|null)] - Type of commit
    * @param {commitCallback} [options.onClick] - OnClick event for the commit dot
+   * @param {Object} [options.representedObject] - Any object which is related to this commit. Can be used in onClick or the formatter. Useful to bind the commit to external objects such as database id etc.
    *
    * @this Commit
    **/
@@ -842,6 +843,7 @@
     this.dotStrokeColor = options.dotStrokeColor || this.template.commit.dot.strokeColor || options.color;
     this.type = options.type || null;
     this.onClick = options.onClick || null;
+    this.representedObject = options.representedObject || null;
     this.parentCommit = options.parentCommit;
     this.x = options.x;
     this.y = options.y;


### PR DESCRIPTION
This required a bit of refactoring in order to utilize the already-existing hover functionality which serves to fetch the currently hovered commit.
I also added a jsdoc `commitCallback` type that is used twice. Once as a parameter for the new `applyCommits` function which serves as an abstracted way of determining the commit related to the current mouse event, and it also serves as the `onClick` parameter for the Commit. 

Due to the refactoring, the actual implementation of the onClick event is rather simple:

``` Javascript
GitGraph.prototype.click = function ( event ) {
    this.gitgraph.applyCommits(event, function(commit, isOverCommit) {
      if (isOverCommit && !(commit.onClick === null)) {
        commit.onClick(commit, true);
      }
    });
  };
```

So it would be trivially easy to also add support for right click, and others. I may go on and implement additional event handlers, but first I wanted to make sure that the way I structured this is ok with you and you'd be willing to merge this.

Cheers & Thanks for a great library!