### PR TITLE
Fix scaling in inverse orientation

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -275,13 +275,11 @@
     this.canvas.width = unscaledResolution.x * scalingFactor;
     this.canvas.height = unscaledResolution.y * scalingFactor;
 
-    this.context.scale( scalingFactor, scalingFactor );
-
     // Clear All
     this.context.clearRect( 0, 0, this.canvas.width, this.canvas.height );
 
     // Add some margin
-    this.context.translate( this.marginX, this.marginY );
+    this.context.translate( this.marginX * scalingFactor, this.marginY * scalingFactor );
 
     // Translate for inverse orientation
     if ( this.template.commit.spacingY > 0 ) {
@@ -292,6 +290,8 @@
       this.context.translate( this.canvas.width - this.marginX * 2, 0 );
       this.offsetX = this.canvas.width - this.marginX * 2;
     }
+
+    this.context.scale( scalingFactor, scalingFactor );
 
     // Render branchs
     for ( var i = this.branchs.length - 1, branch; !!(branch = this.branchs[ i ]); i-- ) {


### PR DESCRIPTION
In an inverse orientation, if the scalingFactor is anything but 1, then parts of the graph will get cut off.
This patch fixes this by moving the context.scale call to after doing the inverse orientation translation.
Also, applies the scalingFactor to the margins

Signed-off-by: Jon Ringle <jringle@gridpoint.com>