### PR TITLE
Improve tag and message alignment

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -275,13 +275,11 @@
     this.canvas.width = unscaledResolution.x * scalingFactor;
     this.canvas.height = unscaledResolution.y * scalingFactor;
 
-    this.context.scale( scalingFactor, scalingFactor );
-
     // Clear All
     this.context.clearRect( 0, 0, this.canvas.width, this.canvas.height );
 
     // Add some margin
-    this.context.translate( this.marginX, this.marginY );
+    this.context.translate( this.marginX * scalingFactor, this.marginY * scalingFactor );
 
     // Translate for inverse orientation
     if ( this.template.commit.spacingY > 0 ) {
@@ -292,6 +290,8 @@
       this.context.translate( this.canvas.width - this.marginX * 2, 0 );
       this.offsetX = this.canvas.width - this.marginX * 2;
     }
+
+    this.context.scale( scalingFactor, scalingFactor );
 
     // Render branchs
     for ( var i = this.branchs.length - 1, branch; !!(branch = this.branchs[ i ]); i-- ) {

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -1,6 +1,8 @@
 (function () {
   "use strict";
 
+  var maxTagWidth = 0;
+
   /**
    * Emit an event on the given element.
    * @param {HTMLElement} element - DOM element to trigger the event on.
@@ -839,23 +841,21 @@
     this.context.font = this.messageFont;
 
     // Tag
-    var tagWidth = this.template.commit.tag.spacingX;
+    var tagWidth = maxTagWidth;
     if ( this.tag !== null ) {
       this.parent.tagNum++;
-      var textWidth = this.context.measureText(this.tag).width;
+
       if ( this.template.branch.labelRotation !== 0 ) {
-        var textHeight = getFontHeight(this.tagFont);
-        drawTextBG( this.context,
-          this.x - this.dotSize/2,
-          ((this.parent.columnMax + 1) * this.template.commit.tag.spacingY) - this.template.commit.tag.spacingY/2 + (this.parent.tagNum % 2) * textHeight * 1.5,
-          this.tag, "black", this.tagColor, this.tagFont, 0 );
+        var tagHeight = getFontHeight(this.tagFont);
+        var tagY = ((this.parent.columnMax + 1) * this.template.commit.tag.spacingY) - this.template.commit.tag.spacingY/2 + (this.parent.tagNum % 2) * tagHeight + 4;
+        drawTextBG( this.context, this.x - this.dotSize/2, tagY, this.tag, "black", this.tagColor, this.tagFont, 0 );
       } else {
-        drawTextBG( this.context,
-          ((this.parent.columnMax + 1) * this.template.commit.tag.spacingX) - this.template.commit.tag.spacingX/2 + textWidth/2,
-          this.y - this.dotSize/2,
-          this.tag, "black", this.tagColor, this.tagFont, 0 );
+        tagWidth = getTextWidth( this.context, this.tagFont, this.tag );
+        var tagX = ((this.parent.columnMax) * this.template.commit.tag.spacingX) + (tagWidth/2) + this.dotSize*3;
+        drawTextBG( this.context, tagX, this.y - this.dotSize/2, this.tag, "black", this.tagColor, this.tagFont, 0 );
+
+        maxTagWidth = Math.max(maxTagWidth, tagWidth);
       }
-      tagWidth = (tagWidth < textWidth) ? textWidth : tagWidth;
     }
 
     // Message
@@ -872,7 +872,7 @@
       }
 
       this.context.fillStyle = this.messageColor;
-      this.context.fillText( message, ((this.parent.columnMax + 1) * this.template.branch.spacingX) + tagWidth, this.y + this.dotSize/2);
+      this.context.fillText( message, ((this.parent.columnMax) * this.template.branch.spacingX) + maxTagWidth + this.dotSize*4, this.y + this.dotSize/2);
     }
   };
 
@@ -1112,6 +1112,14 @@
     return result;
   };
 
+  var getTextWidth = function ( context, font, text ) {
+    context.save();
+    context.font = font;
+    var width = context.measureText(text).width;
+    context.restore();
+    return width;
+  }
+
   function booleanOptionOr ( booleanOption, defaultOption ) {
     return (typeof booleanOption === "boolean") ? booleanOption : defaultOption;
   }
@@ -1123,7 +1131,7 @@
     context.textAlign = "center";
 
     context.font = font;
-    var width = context.measureText(text).width;
+    var width = getTextWidth(context, font, text);
     var height = getFontHeight(font);
 
     context.beginPath();


### PR DESCRIPTION
The tag text width calculation before calling drawTextBG was calculating
a different width than the drawTextBG, because different context.font was
set at the time.

Also keep track of the maxTagWidth and use it to determine where the
message text should go.

Signed-off-by: Jon Ringle <jringle@gridpoint.com>
