### PR TITLE
Branch from current commit or a specific commit

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -477,7 +477,8 @@
    *
    * @param {Object} options - Options of branch
    * @param {GitGraph} options.parent - GitGraph constructor
-   * @param {Branch} [options.parentBranch] - Parent branch
+   * @param {Branch} [options.parentBranch = options.parentCommit.branch] - Parent branch
+   * @param {Commit} [options.parentCommit = options.parentBranch.commits.slice(-1)[0]] - Parent commit
    * @param {String} [options.name = "no-name"] - Branch name
    *
    * @this Branch
@@ -491,7 +492,22 @@
     // Options
     options = (typeof options === "object") ? options : {};
     this.parent = options.parent;
-    this.parentBranch = options.parentBranch;
+    if ( options.parentCommit && options.parentBranch ) {
+      if ( options.parentCommit.branch !== options.parentBranch ) {
+        return;
+      }
+      this.parentCommit = options.parentCommit;
+      this.parentBranch = options.parentBranch;
+    } else if ( options.parentCommit ) {
+      this.parentCommit = options.parentCommit;
+      this.parentBranch = options.parentCommit.branch;
+    } else if ( options.parentBranch ) {
+      this.parentCommit = options.parentBranch.commits.slice( -1 )[ 0 ];
+      this.parentBranch = options.parentBranch;
+    } else {
+      this.parentCommit = null;
+      this.parentBranch = null;
+    }
     this.name = (typeof options.name === "string") ? options.name : "no-name";
     this.context = this.parent.context;
     this.template = this.parent.template;
@@ -519,6 +535,17 @@
     // Options with auto value
     this.offsetX = this.column * this.spacingX;
     this.offsetY = this.column * this.spacingY;
+
+    // Add start point
+    if (this.parentBranch) {
+      this.startPoint = {
+        x: this.parentBranch.offsetX - this.parent.commitOffsetX + this.template.commit.spacingX,
+        y: this.parentBranch.offsetY - this.parent.commitOffsetY + this.template.commit.spacingY,
+        type: "start"
+      };
+    } else {
+      this.startPoint = null;
+    }
 
     var columnIndex = (this.column % this.template.colors.length);
     this.color = options.color || this.template.branch.color || this.template.colors[ columnIndex ];
@@ -666,11 +693,11 @@
 
     // Fork case: Parent commit from parent branch
     if ( options.parentCommit instanceof Commit === false && this.parentBranch instanceof Branch ) {
-      options.parentCommit = this.parentBranch.commits.slice( -1 )[ 0 ];
+      options.parentCommit = this.parentCommit;
     }
 
     // First commit
-    var isFirstBranch = options.parentCommit instanceof Commit;
+    var isFirstBranch = !( options.parentCommit instanceof Commit );
     var isPathBeginning = this.path.length === 0;
 
     options.showLabel = (isPathBeginning && this.showLabel) ? true : false;
@@ -690,21 +717,26 @@
       type: "join"
     };
 
-    if ( isFirstBranch && isPathBeginning ) {
-      var parent = {
-        x: commit.parentCommit.branch.offsetX - this.parent.commitOffsetX + this.template.commit.spacingX,
-        y: commit.parentCommit.branch.offsetY - this.parent.commitOffsetY + this.template.commit.spacingY,
-        type: "start"
-      };
-      this.path.push( JSON.parse( JSON.stringify( parent ) ) ); // Elegant way for cloning an object
+    if ( !isFirstBranch && isPathBeginning ) {
+      // Start point on parent branch
+      this.pushPath( this.startPoint );
+      // Move to this branch
+      this.pushPath( {
+        x: this.startPoint.x - this.parentBranch.offsetX + this.offsetX - this.template.commit.spacingX,
+        y: this.startPoint.y - this.parentBranch.offsetY + this.offsetY - this.template.commit.spacingY,
+        type: "join"
+      } );
+
+      // Extend parent branch
+      var parent = JSON.parse( JSON.stringify( this.startPoint ) ); // Elegant way for cloning an object
       parent.type = "join";
-      this.parentBranch.path.push( parent );
+      this.parentBranch.pushPath( parent );
     } else if ( isPathBeginning ) {
       point.type = "start";
     }
 
     // Increment commitOffset for next commit position
-    this.path.push( point );
+    this.pushPath( point );
 
     this.parent.commitOffsetX += this.template.commit.spacingX * (options.showLabel ? 2 : 1);
     this.parent.commitOffsetY += this.template.commit.spacingY * (options.showLabel ? 2 : 1);
@@ -780,17 +812,17 @@
       y: this.offsetY + this.template.commit.spacingY * (targetCommit.showLabel ? 3 : 2) - this.parent.commitOffsetY,
       type: "join"
     };
-    this.path.push( JSON.parse( JSON.stringify( endOfBranch ) ) ); // Elegant way for cloning an object
+    this.pushPath( JSON.parse( JSON.stringify( endOfBranch ) ) ); // Elegant way for cloning an object
 
     var mergeCommit = {
       x: targetCommit.x,
       y: targetCommit.y,
       type: "end"
     };
-    this.path.push( mergeCommit );
+    this.pushPath( mergeCommit );
 
     endOfBranch.type = "start";
-    this.path.push( endOfBranch ); // End of branch for future commits
+    this.pushPath( endOfBranch ); // End of branch for future commits
 
     // Auto-render
     this.parent.render();
@@ -822,6 +854,37 @@
     for ( ; ; this.column++ ) {
       if ( !( this.column in candidates ) || candidates[ this.column ] === 0 ) {
         break;
+      }
+    }
+  };
+
+  /**
+   * Push a new point to path.
+   * This method will combine duplicate points and reject reversed points.
+   * 
+   * @this Branch
+   */
+  Branch.prototype.pushPath = function (point) {
+    var lastPoint = this.path.slice( -1 )[ 0 ];
+    if ( !lastPoint ) {
+      this.path.push( point );
+    } else if ( lastPoint.x === point.x && lastPoint.y === point.y ) {
+      if ( lastPoint.type !== "start" && point.type === "end" ) {
+        lastPoint.type = "end";
+      } else if ( point.type === "join" ) {
+        
+      } else {
+        this.path.push( point );
+      }
+    } else {
+      if ( point.type === "join" ) {
+        if ( ( point.x - lastPoint.x ) * this.template.commit.spacingX < 0 ) {
+          this.path.push( point );
+        } else if ( ( point.y - lastPoint.y ) * this.template.commit.spacingY < 0 ) {
+          this.path.push( point );
+        }
+      } else {
+        this.path.push( point );
       }
     }
   };

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -1097,6 +1097,9 @@
         isReversed
         && _isVertical( this.parent )
         && Math.abs( this.y - this.parentCommit.y ) > Math.abs( this.template.commit.spacingY )
+      ) || (
+        _isVertical( this.parent )
+        && commitSpaceDelta > 1
       );
       var alphaX = (isArrowVertical)
         ? 0
@@ -1106,6 +1109,9 @@
         isReversed
         && _isHorizontal( this.parent )
         && Math.abs( this.x - this.parentCommit.x ) > Math.abs( this.template.commit.spacingX )
+      ) || (
+        _isHorizontal( this.parent )
+        && commitSpaceDelta > 1
       );
       var alphaY = (isArrowHorizontal)
         ? 0

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -538,11 +538,19 @@
 
     // Add start point
     if (this.parentBranch) {
-      this.startPoint = {
-        x: this.parentBranch.offsetX - this.parent.commitOffsetX + this.template.commit.spacingX,
-        y: this.parentBranch.offsetY - this.parent.commitOffsetY + this.template.commit.spacingY,
-        type: "start"
-      };
+      if ( this.parentCommit === this.parentBranch.commits.slice( -1 )[ 0 ] ) {
+        this.startPoint = {
+          x: this.parentBranch.offsetX - this.parent.commitOffsetX + this.template.commit.spacingX,
+          y: this.parentBranch.offsetY - this.parent.commitOffsetY + this.template.commit.spacingY,
+          type: "start"
+        };
+      } else {
+        this.startPoint = {
+          x: this.parentCommit.x,
+          y: this.parentCommit.y,
+          type: "start"
+        };
+      }
     } else {
       this.startPoint = null;
     }


### PR DESCRIPTION
#86 

Changes:
* Add `parentCommit` option parameter to `Branch`;
* Default the parent commit to the latest commit of the parent branch before creating this branch (instead of the latest one before the first commit of this branch);
* Add `pushPath` to push points into `path` in order to avoid duplicate points (which causes unexpected short line at the duplicate point in bezier mode).

Test code:
````javascript
<html>
<head>
<script type="text/javascript" src="js/gitgraph.js"></script>
<script type="text/javascript">

function test() {
    var canvas = document.getElementById('canvas');
    
    var template = new GitGraph.Template({
        commit: {
            spacingY: -40
        }
    });
    
    var graph = new GitGraph({
        canvas: canvas,
        orientation: 'vertical',
        template: template
    });
    
    var master = graph.branch('master');
    master.commit();
    branch = master.branch('branch');
    master.commit();
    branch.commit();
    var branch2 = master.branch('branch2');
    branch2.commit();
    master.commit();
    branch2.branch('branch3').commit();
    master.merge(branch);
    
    var master2 = graph.orphanBranch('new master');
    master2.commit();
    master2.branch('new branch').commit();
    master2.commit();
}

</script>
</head>
<body onload="test()">
<canvas id="canvas" width="640" height="480">
</canvas>
</body>
</html>
````

Current develop:
<img width="833" alt="screen shot 2015-12-03 at 2 40 49 pm" src="https://cloud.githubusercontent.com/assets/4104205/11572074/7ba83b02-99cd-11e5-9178-7fac5694475b.png">

This PR:
<img width="842" alt="screen shot 2015-12-03 at 2 40 26 pm" src="https://cloud.githubusercontent.com/assets/4104205/11572080/86d80b7e-99cd-11e5-95cf-d7613a32afdb.png">
