### PR TITLE
[Bug Fix] Align tags properly

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -939,12 +939,11 @@
       this.arrow();
     }
 
-    this.context.font = this.messageFont;
-
     // Tag
     var tagWidth = this.template.commit.tag.spacingX;
     if ( this.tag !== null ) {
       this.parent.tagNum++;
+      this.context.font = this.tagFont;
       var textWidth = this.context.measureText( this.tag ).width;
       if ( this.template.branch.labelRotation !== 0 ) {
         var textHeight = getFontHeight( this.tagFont );
@@ -960,6 +959,8 @@
       }
       tagWidth = (tagWidth < textWidth) ? textWidth : tagWidth;
     }
+
+    this.context.font = this.messageFont;
 
     var commitOffsetLeft = (this.parent.columnMax + 1) * this.template.branch.spacingX + tagWidth;
 


### PR DESCRIPTION
#103

Cause: 

- Tag's textWidth is measured in message's font-size instead of tag's font-size.

Changes:

- Apply tag's font-size to context before measuring tag's textWidth.
- Apply message's font-size to context after drawing tag.

You can test it on gitflowsupport.js.