### PR TITLE
Restore line dash after applying it to branch

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -585,11 +585,20 @@
 
     this.context.lineWidth = this.lineWidth;
     this.context.strokeStyle = this.color;
+    
+    var prevLineDash = undefined;
     if ( this.context.setLineDash !== undefined ) {
-      this.context.setLineDash( this.lineDash );
+      prevLineDash = this.context.getLineDash();
+      this.context.setLineDash(this.lineDash);
     }
+    
     this.context.stroke();
     this.context.closePath();
+    
+    //Restore previous line dash setting, if any
+    if ( prevLineDash !== undefined ) {
+      this.context.setLineDash(prevLineDash);
+    }
   };
 
   /**


### PR DESCRIPTION
Changing the line dash for a branch propagates it to other objects
like commits or tags that do not explicitly set it before start
drawing.

Prevent it by saving the dash setting before being overridden and
restore it afterwards.