### PR TITLE
Fix offsetX and offsetY for older FF

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -374,8 +374,18 @@
    **/
   GitGraph.prototype.applyCommits = function ( event, callbackFn ) {
     // Fallback onto layerX/layerY for older versions of Firefox.
-    var offsetX = event.offsetX || (event.pageX - $("#" + this.elementId).offset().left);
-    var offsetY = event.offsetY || (event.pageY - $("#" + this.elementId).offset().top);
+    function getOffsetById(id) {
+            var el = document.getElementById(id);
+            var rect = el.getBoundingClientRect();
+
+            return {
+                top: rect.top + document.body.scrollTop,
+                left: rect.left + document.body.scrollLeft
+            };
+        }
+
+    var offsetX = event.offsetX || (event.pageX - getOffsetById(this.elementId).left);
+    var offsetY = event.offsetY || (event.pageY - getOffsetById(this.elementId).top);
 
     for ( var i = 0, commit; !!(commit = this.commits[ i ]); i++ ) {
       var distanceX = (commit.x + (this.offsetX + this.marginX) / this.scalingFactor - offsetX);

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -374,8 +374,8 @@
    **/
   GitGraph.prototype.applyCommits = function ( event, callbackFn ) {
     // Fallback onto layerX/layerY for older versions of Firefox.
-    var offsetX = event.offsetX || event.layerX;
-    var offsetY = event.offsetY || event.layerY;
+    var offsetX = event.offsetX || (event.pageX - $("#" + this.elementId).offset().left);
+    var offsetY = event.offsetY || (event.pageY - $("#" + this.elementId).offset().top);
 
     for ( var i = 0, commit; !!(commit = this.commits[ i ]); i++ ) {
       var distanceX = (commit.x + (this.offsetX + this.marginX) / this.scalingFactor - offsetX);


### PR DESCRIPTION
Hello,

I had an issue when the canvas is not on the top of the page. (Firefox 38.XX)
I change these two lines in order to be compatible with old Firefox because according to the definition of layerY.

_This property takes scrolling of the page into account, and returns a value relative to the whole of the document, unless the event occurs inside a positioned element, **where the returned value is relative to the top left of the positioned element.**_

pageY take in account the whole page.

Thanks for your works!