### PR TITLE
Improve readability of markdown files as plaintext

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,16 @@ Glad to hear you'd like to help us improving the library. Here's the how-to!
 
 Sounds nice! Please proceed as following:
 
-1. **Search for existing issues.** Sometimes, other folks may have reported the same issue and it'd be nice not to duplicate them.
-2. If possible, please **create an isolated and reproducible test case.** Make use of [jsFiddle](jsfiddle.net) - for instance - to share your isolated test cases. We won't hold it against you for feature requests, but a live [POC](http://en.wikipedia.org/wiki/Proof_of_concept) is sometimes easier to catch.
-3. **Share as much information as possible.** Include browser and version, version of gitgraph.js, etc. where appropriate. That can help us to reproduce the bug, if so.
+1. **Search for existing issues.** Sometimes, other folks may have reported the
+   same issue and it'd be nice not to duplicate them.
+2. If possible, please **create an isolated and reproducible test case.** Make
+   use of [jsFiddle](jsfiddle.net) - for instance - to share your isolated test
+   cases. We won't hold it against you for feature requests, but a live [POC][]
+   is sometimes easier to catch.
+   [POC]: http://en.wikipedia.org/wiki/Proof_of_concept
+3. **Share as much information as possible.** Include browser and version,
+   version of gitgraph.js, etc. where appropriate. That can help us to reproduce
+   the bug, if so.
 
 ## Or wanna contribute to the code?
 
@@ -17,17 +24,24 @@ Github's Pull Request is a fantastic tool to contribute to the code.
 
 Just keep in mind the following rules:
 
-- Change must be done in `src/` files, eventually `test/` or `examples/`, that's all.
+- Change must be done in `src/` files, eventually `test/` or `examples/`, that's
+  all.
 - You'd be nice not to pollute your pull request with unintended changes.
-- Pull requests should always be against the `develop` branch, never against `master` nor `gh-pages`.
+- Pull requests should always be against the `develop` branch, never against
+  `master` nor `gh-pages`.
 
-Once you send a Pull Request, your code will be check with [Travis CI](https://travis-ci.org/nicoespeon/gitgraph.js) to tell whether you break the build or not. The Travis test should pass before we accept any Pull Request.
+Once you send a Pull Request, your code will be checked with [Travis CI][] to
+tell whether you break the build or not. The Travis test should pass before we
+accept any Pull Request.
+[Travis CI]: https://travis-ci.org/nicoespeon/gitgraph.js
 
 ## Check about our coding standards
 
-Please follow our coding standards as best as you can to keep consistency over code.
+Please follow our coding standards as best as you can to keep consistency over
+code.
 
-The [.editorconfig](https://github.com/nicoespeon/gitgraph.js/blob/develop/.editorconfig) file should help you configure your IDE to do so.
+The [.editorconfig][] file should help you configure your IDE to do so.
+[.editorconfig]: https://github.com/nicoespeon/gitgraph.js/blob/develop/.editorconfig
 
 ### JS
 
@@ -40,10 +54,14 @@ The [.editorconfig](https://github.com/nicoespeon/gitgraph.js/blob/develop/.edit
 
 - Adhere to the (default) [CSScomb](http://csscomb.com/) property order
 - Multiple-line approach (one property and value per line)
-- Always a space after a property's colon (.e.g, `display: block;` and not `display:block;`)
+- Always a space after a property's colon (.e.g, `display: block;` and not
+  `display:block;`)
 - End all lines with a semi-colon
 - For multiple, comma-separated selectors, place each selector on its own line
-- Attribute selectors, like `input[type="text"]`, should always wrap the attribute's value in double quotes, for consistency and safety (see [this blog post on unquoted attribute values](http://mathiasbynens.be/notes/unquoted-attribute-values) that can lead to XSS attacks).
+- Attribute selectors, like `input[type="text"]`, should always wrap the
+  attribute's value in double quotes, for consistency and safety (see [this blog
+  post on unquoted attribute values][blog] that can lead to XSS attacks).
+  [blog]: http://mathiasbynens.be/notes/unquoted-attribute-values
 
 ### HTML
 
@@ -54,6 +72,8 @@ The [.editorconfig](https://github.com/nicoespeon/gitgraph.js/blob/develop/.edit
 
 ## License
 
-By contributing your code, you agree to license your contribution under the terms of [the MIT license](https://github.com/nicoespeon/gitgraph.js/blob/master/LICENSE.md).
+By contributing your code, you agree to license your contribution under the
+terms of the [MIT license][]
+[MIT license]: https://github.com/nicoespeon/gitgraph.js/blob/master/LICENSE.md
 
 [> What does that mean?](http://choosealicense.com/licenses/mit/)

--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ Production files are available under the `build/` directory.
 
 ## Report a bug / Ask for a feature
 
-You found some nasty bug or have a cool feature request? [Just open a new issue](https://github.com/nicoespeon/gitgraph.js/issues).
+You found some nasty bug or have a cool feature request? [Just open a new
+issue](https://github.com/nicoespeon/gitgraph.js/issues).
 
-Please have a look at [the Issue Guidelines](https://github.com/necolas/issue-guidelines/blob/master/CONTRIBUTING.md) from [Nicolas Gallagher](https://github.com/necolas) before doing so.
+Please have a look at the [Issue Guidelines][] from [Nicolas Gallagher][] before
+doing so.
+[Issue Guidelines]: https://github.com/necolas/issue-guidelines/blob/master/CONTRIBUTING.md
+[Nicolas Gallagher]: https://github.com/necolas
 
 ## Documentation
 
@@ -30,18 +34,25 @@ The JavaScript source code is documented with [JSDoc](http://usejsdoc.org/).
 
 ## Contributing
 
-Editor preferences are available in [the editor config](https://github.com/nicoespeon/gitgraph.js/blob/master/.editorconfig) for easy use in common text editors. Read more and download plugins at <http://editorconfig.org>.
+Editor preferences are available in for [the editor config][] easy use in common
+text editors. Read more and download plugins at <http://editorconfig.org>.
+[the editor config]: https://github.com/nicoespeon/gitgraph.js/blob/master/.editorconfig
 
-The project uses [Grunt](http://gruntjs.com) with convenient methods for our workflow. It's how we lint our code, run tests, generate documentation, etc. To use it, install the required dependencies as directed and then run the following Grunt commands.
+The project uses [Grunt](http://gruntjs.com) with convenient methods for our
+workflow. It's how we lint our code, run tests, generate documentation, etc. To
+use it, install the required dependencies as directed and then run the following
+Grunt commands.
 
 ### Install Grunt
 
 From the command line:
 
 - Install `grunt-cli` globally with `npm install -g grunt-cli`.
-- Install [the necessary local dependencies](https://github.com/nicoespeon/gitgraph.js/blob/master/.editorconfig) with `npm install`.
+- Install [the necessary local dependencies][] with `npm install`.
+[the necessary local dependencies]: https://github.com/nicoespeon/gitgraph.js/blob/master/.editorconfig
 
-When completed, you'll be able to run the various Grunt commands provided from the command line.
+When completed, you'll be able to run the various Grunt commands provided from
+the command line.
 
 [> Need more information about how to get started with Grunt?](http://gruntjs.com/getting-started)
 
@@ -49,23 +60,30 @@ When completed, you'll be able to run the various Grunt commands provided from t
 
 #### test code - `grunt test`
 
-Check source code against [JSHint](http://www.jshint.com/) then runs unit tests with [Jasmine](https://jasmine.github.io/).
+Check source code against [JSHint][] then runs unit tests with [Jasmine][].
+[JSHint]: http://www.jshint.com/
+[Jasmine]: https://jasmine.github.io/
 
 #### generate documentation - `grunt doc`
 
-Generate source code documentation into `dist/docs/` (not versioned) with [JSDoc](http://usejsdoc.org/).
+Generate source code documentation into `dist/docs/` (not versioned) with
+[JSDoc](http://usejsdoc.org/).
 
 #### compile a non-versioned release - `grunt dist`
 
-Clean `dist/` directory, lint code, output the minified release into `dist/gitgraph.min.js` and generate the documentation into `dist/docs/`.
+Clean `dist/` directory, lint code, output the minified release into
+`dist/gitgraph.min.js` and generate the documentation into `dist/docs/`.
 
 #### compile a new release - `grunt release`
 
-Lint code, output the source and minified releases into `build/` and generate the official documentation into `docs/`.
+Lint code, output the source and minified releases into `build/` and generate
+the official documentation into `docs/`.
 
 #### open a live reload server - `grunt server`
 
-For a better code experience, this grunt task opens a live server in your favorite browser. This server is automatically reloaded when you save a project file.
+For a better code experience, this grunt task opens a live server in your
+favorite browser. This server is automatically reloaded when you save a project
+file.
 
 Please note that `examples/index.html` is the default file for testing ;)
 
@@ -83,8 +101,10 @@ Releases will be numbered with the following format:
 
 And constructed with the following guidelines:
 
-- Breaking backward compatibility bumps the `<major>` (and resets the `<minor>` and `<patch>`)
-- New additions without breaking backward compatibility bumps the `<minor>` (and resets the `<patch>`)
+- Breaking backward compatibility bumps the `<major>` (and resets the `<minor>`
+  and `<patch>`)
+- New additions without breaking backward compatibility bumps the `<minor>` (and
+  resets the `<patch>`)
 - Bug fixes and misc. changes bumps the `<patch>`
 
 ## Authors and contributors
@@ -95,6 +115,7 @@ And constructed with the following guidelines:
 
 ## Copyright and License
 
-Copyright (c) 2013 Nicolas CARLO and Fabien BERNARD under [the MIT license](https://github.com/nicoespeon/gitgraph.js/blob/master/LICENSE.md).
+Copyright (c) 2013 Nicolas CARLO and Fabien BERNARD under the [MIT license][]
+[MIT license]: https://github.com/nicoespeon/gitgraph.js/blob/master/LICENSE.md
 
 [> What does that mean?](http://choosealicense.com/licenses/mit/)


### PR DESCRIPTION
When reading in a terminal, it's much nicer to have shorter line lengths. 

In this change I wrapped lines at 100 characters for the most part, and moved link markup to the end of paragraphs.

Unfortunately GitHub doesn't give a very nice diff of what changed, but using the `--word-diff` option in the terminal should ignore the wrapping changes