### PR TITLE
Added fix for JSHint via Grunt (null path warning).

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -116,7 +116,8 @@ module.exports = function ( grunt ) {
       src: [ "src/*.js" ],
       options: {
         force: true,
-        jshintrc: ".jshintrc"
+        jshintrc: ".jshintrc",
+        reporterOutput : ""
       }
     },
 


### PR DESCRIPTION
Experienced the following warning whilst attempting to run JSHint via Grunt:

`Warning: Path must be a string. Received null Use --force to continue.`

causing Grunt to fail unless forced to continue. 

This PR applies a workaround suggested as part of the original issue raised for JSHint: 

[https://github.com/jshint/jshint/issues/2922](https://github.com/jshint/jshint/issues/2922)



