### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Project page: <http://gitgraphjs.com/>
 You have different options to start with the library:
 
 - [Download the latest release](https://github.com/nicoespeon/gitgraph.js/releases/latest).
-- Clone the repo: `git clone git://github.com/nicoespeon/gitgraph.js.git`.
+- Clone the repo: `git clone git@github.com:nicoespeon/gitgraph.js.git`.
 - Install with [npm](https://www.npmjs.com): `npm install --save gitgraph.js`.
 - Install with [Bower](http://bower.io/): `bower install gitgraph.js`.
 - Use [the CDNjs hosted lib](https://cdnjs.com/libraries/gitgraph.js).


### PR DESCRIPTION
It seems that git@ becomes git://