### PR TITLE
fix issue 140 wrong arrow angle

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -32,7 +32,7 @@ var myTemplate = new GitGraph.Template(myTemplateConfig);
  ***********************/
 
 var config = {
-  template: "metro", // could be: "blackarrow" or "metro" or `myTemplate` (custom Template object)
+  template: "blackarrow", // could be: "blackarrow" or "metro" or `myTemplate` (custom Template object)
   reverseArrow: false, // to make arrows point to ancestors, if displayed
   orientation: "vertical",
   // mode: "compact" // special compact mode: hide messages & compact graph
@@ -53,7 +53,7 @@ gitGraph.commit("Initial commit");
 gitGraph.commit("My second commit").commit("Add awesome feature");
 
 // Create a new "dev" branch from "master" with some custom configuration
-var dev = gitGraph.branch({
+var dev = master.branch({
   name: "dev",
   color: "#F00",
   commitDefaultOptions: {
@@ -77,6 +77,10 @@ var commitConfig = {
   author: "Me <me@planee.fr>"
 };
 gitGraph.commit(commitConfig);
+
+// Create another from "master"
+var feature3 = master.branch("feature3")
+feature3.commit().commit();
 
 /***********************
  *      CHECKOUT       *
@@ -166,6 +170,13 @@ test.merge(master, {
   message: "New release",
   tag: "v1.0.0"
 });
+
+// Create different branches from an empty one and do some commits
+var features = master.branch("features")
+var feature1 = features.branch("feature1")
+var feature2 = features.branch("feature2")
+feature1.commit();
+feature2.commit().commit();
 
 /***********************
  *       EVENTS        *

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -727,19 +727,13 @@
 
     if (!isFirstBranch && isPathBeginning) {
       this.pushPath(this.startPoint);
-
-      // Trace path from parent branch if it has commits already
-      if (this.parentBranch.commits.length > 0) {
-        this.pushPath({
-          x: this.startPoint.x - this.parentBranch.offsetX + this.offsetX - this.template.commit.spacingX,
-          y: this.startPoint.y - this.parentBranch.offsetY + this.offsetY - this.template.commit.spacingY,
-          type: "join"
-        });
-
-        var parent = _clone(this.startPoint);
-        parent.type = "join";
-        this.parentBranch.pushPath(parent);
-      }
+      // Add a path point to startpoint + offset - template spacing
+      // So that line will not go through commit of other branches
+      this.pushPath({
+        x: this.startPoint.x + this.offsetX - this.template.commit.spacingX,
+        y: this.startPoint.y + this.offsetY - this.template.commit.spacingY,
+        type: "join"
+      });
     } else if (isPathBeginning) {
       point.type = "start";
     }


### PR DESCRIPTION
#140 

The steps to reproduce error:

var master = gitgraph.branch("master");
master.commit();
var branch0 = master.branch("branch0");
var branch1 = branch0.branch("branch1");
var branch2 = branch0.branch("branch2");
var branch3 = branch0.branch("branch3");

branch1.commit()
branch2.commit()
branch3.commit()

The arrow point from branch0 to branch2, branch3
will have vertical directions.

The cause:
There is a property 'isForkCommit' when drawing arrow
which if set to true, the direction of arrow will
re-calculate the vertical if difference in Y direction
is larger than Y spacing of template.
The direction of branch1 arrow is correct since
difference in Y direction is equal Y spacing of template.

The fix:
The property 'isForkCommit' seems unused.
Simply remove the property from calculation of arrow direction
can solve the issue.
However, more test on other cases are required to ensure that
removing isForkCommit property not affect other render.