### PR TITLE
Issue140 vertical arrow with multiple branch commit

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -768,19 +768,13 @@
 
     if (!isFirstBranch && isPathBeginning) {
       this.pushPath(this.startPoint);
-
-      // Trace path from parent branch if it has commits already
-      if (this.parentBranch.commits.length > 0) {
-        this.pushPath({
-          x: this.startPoint.x - this.parentBranch.offsetX + this.offsetX - this.template.commit.spacingX,
-          y: this.startPoint.y - this.parentBranch.offsetY + this.offsetY - this.template.commit.spacingY,
-          type: "join"
-        });
-
-        var parent = _clone(this.startPoint);
-        parent.type = "join";
-        this.parentBranch.pushPath(parent);
-      }
+      // Add a path point to startpoint + offset - template spacing
+      // So that line will not go through commit of other branches
+      this.pushPath({
+        x: commit.x,
+        y: this.startPoint.y - this.template.commit.spacingY,
+        type: "joint"
+      });
     } else if (isPathBeginning) {
       point.type = "start";
     }

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -770,11 +770,19 @@
       this.pushPath(this.startPoint);
       // Add a path joint to startpoint + template spacing
       // So that line will not go through commit of other branches
-      this.pushPath({
-        x: commit.x,
-        y: this.startPoint.y - this.template.commit.spacingY,
-        type: "joint"
-      });
+      if ((this.parent.orientation === "vertical-reverse") || (this.parent.orientation === "vertical")) {
+        this.pushPath({
+          x: commit.x,
+          y: this.startPoint.y - this.template.commit.spacingY,
+          type: "joint"
+        });
+      } else {
+        this.pushPath({
+          x: this.startPoint.x - this.template.commit.spacingX,
+          y: commit.y,
+          type: "joint"
+        });
+      }
     } else if (isPathBeginning) {
       point.type = "start";
     }

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -504,7 +504,7 @@
     this.height = 0;
     this.width = 0;
     this.commits = [];
-    this.path = []; // Path to draw, this is an array of points {x, y, type("start"|"join"|"end")}
+    this.path = []; // Path to draw, this is an array of points {x, y, type("start"|"joint"|"end")}
 
     // Column number calculation for auto-color & auto-offset
     if (typeof options.column === "number") {
@@ -763,12 +763,12 @@
     var point = {
       x: commit.x,
       y: commit.y,
-      type: "join"
+      type: "joint"
     };
 
     if (!isFirstBranch && isPathBeginning) {
       this.pushPath(this.startPoint);
-      // Add a path point to startpoint + offset - template spacing
+      // Add a path joint to startpoint + template spacing
       // So that line will not go through commit of other branches
       this.pushPath({
         x: commit.x,
@@ -932,7 +932,7 @@
       var endOfBranch = {
         x: this.offsetX + this.template.commit.spacingX * (targetCommit.showLabel ? 3 : 2) - this.parent.commitOffsetX,
         y: this.offsetY + this.template.commit.spacingY * (targetCommit.showLabel ? 3 : 2) - this.parent.commitOffsetY,
-        type: "join"
+        type: "joint"
       };
       this.pushPath(_clone(endOfBranch));
 
@@ -994,13 +994,13 @@
     } else if (lastPoint.x === point.x && lastPoint.y === point.y) {
       if (lastPoint.type !== "start" && point.type === "end") {
         lastPoint.type = "end";
-      } else if (point.type === "join") {
+      } else if (point.type === "joint") {
 
       } else {
         this.path.push(point);
       }
     } else {
-      if (point.type === "join") {
+      if (point.type === "joint") {
         if ((point.x - lastPoint.x) * this.template.commit.spacingX < 0) {
           this.path.push(point);
         } else if ((point.y - lastPoint.y) * this.template.commit.spacingY < 0) {


### PR DESCRIPTION
The steps to reproduce error:

var master = gitgraph.branch("master");
master.commit();
var branch0 = master.branch("branch0");
var branch1 = branch0.branch("branch1");
var branch2 = branch0.branch("branch2");

branch1.commit()
branch2.commit()

The arrow point from branch0 to branch2, branch3
will have vertical directions.

The cause:
When create a new commit object, and the commit is the first commit
to this branch, it will first check parentBranch has commit or not.
If it has commit, it will push a new point to path to create a joint
to the path, in order to create more beautiful path.
In the above case, the branch0 has no commit when branch1, 2
commit, so branch1, 2 will have no breakpoint in path, instead
the line will straightly draw from master to the commit.

The fix:
The check of parentCommit is empty or not is actually not needed.
We can always draw the joint.
The position of the joint is calculated as follow:
x equals to commit x, y equals to startpoint y minus template spacing

So if difference of y is larger than template spacing, it will create
a joint at one template spacing then straight line to new commit.

TODO:
Currently the angle of arrow is calculated by various condition.
It will check it is forkcommit or not, then determines that if
it is vertical or not.
I think a simpler way is to calculate angle of arrow by path.
First find the point in path that x, y equal to commit.
Then calculate angle by x,y difference of previous point and current
point