### PR TITLE
Fix incorrect font height in labels and tags when percent width is used

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -1601,7 +1601,7 @@
     var dummyText = document.createTextNode("Mg");
 
     dummy.appendChild(dummyText);
-    dummy.setAttribute("style", "font: " + font + ";");
+    dummy.setAttribute("style", "font: " + font + "; display: inline-block;");
     body.appendChild(dummy);
     var fontHeight = dummy.offsetHeight;
     body.removeChild(dummy);


### PR DESCRIPTION
When canvas is contained in a div with percent width, _getFontHeight will get an incorrect font height. Using 'display: inline-block' in the dummy div gets the correct result.