### PR TITLE
Ff 53 fix

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -375,14 +375,8 @@
         return;
       }
 
-      // Fix firefox MouseEvent
-      if (typeof InstallTrigger !== "undefined") /* == (is Firefox) */ {
-        event.x = event.x ? event.x : event.clientX;
-        event.y = event.y ? event.y : event.clientY;
-      }
-
-      self.tooltip.style.left = event.x + "px"; // TODO Scroll bug
-      self.tooltip.style.top = event.y + "px"; // TODO Scroll bug
+      self.tooltip.style.left = event.clientX + "px"; // TODO Scroll bug
+      self.tooltip.style.top = event.clientY + "px"; // TODO Scroll bug
       if (self.template.commit.tooltipHTMLFormatter !== null) {
         self.tooltip.innerHTML = self.template.commit.tooltipHTMLFormatter(commit);
       } else {


### PR DESCRIPTION
Fixes #164 and should work for all browsers by using event.clientX and event.clientY. (https://developer.mozilla.org/en-US/docs/Web/Events/mouseover)