### PR TITLE
fix wrong arrow angle on branching

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -673,7 +673,17 @@
       this.template.commit.color ||
       this.template.colors[columnIndex];
     options.parent = this.parent;
-    options.parentCommit = options.parentCommit || _getParentCommitFromBranch(this);
+
+    // Set parentCommit
+    // If there is commit in this branch, set parentCommit to last commit of this branch
+    // otherwise, set parentCommit to this.parentCommit, the start point of this branch
+    if (!options.parentCommit) {
+      if (_getLast(this.commits)) {
+        options.parentCommit = _getLast(this.commits);
+      } else {
+        options.parentCommit = this.parentCommit;
+      }
+    }
 
     // Special compact mode
     if (this.parent.mode === "compact" &&
@@ -727,11 +737,6 @@
       this.parent.commitOffsetY += this.template.commit.spacingY;
       options.x = this.offsetX - this.parent.commitOffsetX;
       options.y = this.offsetY - this.parent.commitOffsetY;
-    }
-
-    // Fork case: Parent commit from parent branch
-    if (options.parentCommit instanceof Commit === false && this.parentBranch instanceof Branch) {
-      options.parentCommit = this.parentCommit;
     }
 
     // First commit


### PR DESCRIPTION
Relate Issue:
Issue #159

The Problem:
The following source code will create wrong branch arrow.
```
var graph1 = new GitGraph({
  elementId: 'badGraph',
  mode: 'compact',
  template: 'blackarrow'
});
var m1 = graph1.branch("master");
m1.commit();
var r1 = m1.branch('1.0.x');
m1.commit();
r1.commit();
```
The arrow pointed to r1 commit will pointed from second commit of m1
not follow the line from first commit of m1.

The Cause:
When create a commit, if user does not specify parent commit in options
gitgraph.js will execute following code:
```
options.parentCommit = options.parentCommit || _getParentCommitFromBranch(this);
```
to determine the parent commit of the created commit.
In the function `_getParentCommitFromBranch`, it will try to get the last
commit from current branch, then from parent branch. Since `r1.commit()`
is the first commit in its branch `1.0.x`, it will set its parent commit
to last commit of its parent branch, that is `master`. And since master
already add some new commit, the arrow will point from wrong commit, the
last commit of `master` branch.

There is code that deal with branch case:
```
if (options.parentCommit instanceof Commit === false && this.parentBranch instanceof Branch) {
  options.parentCommit = this.parentCommit;
}
```
It set `parentCommit` to the correct commit. However, since
`options.parentCommit` already been set by previous code, this code will
never execute since `options.parentCommit` is always a Commit.

The fix:
The fix is combining two scenario. If current branch already has commits,
the parentCommit will be set to last commit in this branch. Otherwise,
it will set to parent commit of this branch, which will be the correct commit
instead of last commit of parent branch.