### PR TITLE
Add the ability to put some text in the commit bubble. (commitDotText)

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -77,6 +77,7 @@ var commitConfig = {
   dotStrokeWidth: 10,
   messageHashDisplay: false,
   messageAuthorDisplay: true,
+  messageShort: "C1",
   message: "Alors c'est qui le papa ?",
   tooltipDisplay: false,
   author: "Me <me@planee.fr>"
@@ -128,7 +129,8 @@ test.merge(master, "My special merge commit message");
 
 // Then, continue committing on the "test" branch
 test.commit({
-  message: "It works !"
+  message: "It works !",
+  messageShort: "C2"
 });
 
 var fastForwardBranch = test.branch("fast-forward");

--- a/examples/index.js
+++ b/examples/index.js
@@ -77,7 +77,7 @@ var commitConfig = {
   dotStrokeWidth: 10,
   messageHashDisplay: false,
   messageAuthorDisplay: true,
-  messageShort: "C1",
+  commitDotText: "C1",
   message: "Alors c'est qui le papa ?",
   tooltipDisplay: false,
   author: "Me <me@planee.fr>"
@@ -130,7 +130,7 @@ test.merge(master, "My special merge commit message");
 // Then, continue committing on the "test" branch
 test.commit({
   message: "It works !",
-  messageShort: "C2"
+  commitDotText: "C2"
 });
 
 var fastForwardBranch = test.branch("fast-forward");

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -1208,13 +1208,16 @@
     }
 
     if (this.messageShort !== undefined) {
-      //this.context.textAlign="start"; 
+      var previousTextBaseline = this.context.textBaseline;
+      var previousTextAlign = this.context.textAlign;
+      
       this.context.fillStyle = "#000";
-      var oldTextBaseline = this.context.textBaseline;
-      this.context.textAlign="center";
+      this.context.textAlign = "center";
       this.context.textBaseline = 'middle';
       this.context.fillText(this.messageShort, this.x, this.y); 
-      this.context.textBaseline = oldTextBaseline;
+
+      this.context.textBaseline = previousTextBaseline;
+      this.context.textAlign = previousTextAlign;
     }
 
     // Message

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -1053,7 +1053,7 @@
    * @param {number[]} [options.lineDash = this.template.commit.dot.lineDash]
    *
    * @param {string} [options.message = "He doesn't like George Michael! Boooo!"] - Commit message
-   * @param {string} [options.message] - short commit message (A few chars) to appear on the commit dot
+   * @param {string} [options.commitDotText] - short commit message (A few chars) to appear on the commit dot
    * @param {string} [options.messageColor = options.color] - Specific message color
    * @param {string} [options.messageFont = this.template.commit.message.font] - Font of the message
    * @param {boolean} [options.messageDisplay = this.template.commit.message.display] - Commit message display policy
@@ -1086,8 +1086,8 @@
     this.date = options.date || new Date().toUTCString();
     this.detail = options.detail || null;
     this.sha1 = options.sha1 || (Math.random(100)).toString(16).substring(3, 10);
-    this.message = options.message || options.messageShort || "He doesn't like George Michael! Boooo!";
-    this.messageShort = options.messageShort;
+    this.message = options.message || "He doesn't like George Michael! Boooo!";
+    this.commitDotText = options.commitDotText;
     this.arrowDisplay = options.arrowDisplay;
     this.messageDisplay = _booleanOptionOr(options.messageDisplay, this.template.commit.message.display);
     this.messageAuthorDisplay = _booleanOptionOr(options.messageAuthorDisplay, this.template.commit.message.displayAuthor);
@@ -1207,14 +1207,15 @@
       }
     }
 
-    if (this.messageShort !== undefined) {
+    // Commit Dot Text
+    if (this.commitDotText) {
       var previousTextBaseline = this.context.textBaseline;
       var previousTextAlign = this.context.textAlign;
       
       this.context.fillStyle = "#000";
       this.context.textAlign = "center";
       this.context.textBaseline = 'middle';
-      this.context.fillText(this.messageShort, this.x, this.y); 
+      this.context.fillText(this.commitDotText, this.x, this.y); 
 
       this.context.textBaseline = previousTextBaseline;
       this.context.textAlign = previousTextAlign;

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -1053,6 +1053,7 @@
    * @param {number[]} [options.lineDash = this.template.commit.dot.lineDash]
    *
    * @param {string} [options.message = "He doesn't like George Michael! Boooo!"] - Commit message
+   * @param {string} [options.message] - short commit message (A few chars) to appear on the commit dot
    * @param {string} [options.messageColor = options.color] - Specific message color
    * @param {string} [options.messageFont = this.template.commit.message.font] - Font of the message
    * @param {boolean} [options.messageDisplay = this.template.commit.message.display] - Commit message display policy
@@ -1085,7 +1086,8 @@
     this.date = options.date || new Date().toUTCString();
     this.detail = options.detail || null;
     this.sha1 = options.sha1 || (Math.random(100)).toString(16).substring(3, 10);
-    this.message = options.message || "He doesn't like George Michael! Boooo!";
+    this.message = options.message || options.messageShort || "He doesn't like George Michael! Boooo!";
+    this.messageShort = options.messageShort;
     this.arrowDisplay = options.arrowDisplay;
     this.messageDisplay = _booleanOptionOr(options.messageDisplay, this.template.commit.message.display);
     this.messageAuthorDisplay = _booleanOptionOr(options.messageAuthorDisplay, this.template.commit.message.displayAuthor);
@@ -1203,6 +1205,16 @@
       } else {
         this.detail.style.top = detailPositionTop + DETAIL_OFFSET_TOP_IN_PX + "px";
       }
+    }
+
+    if (this.messageShort !== undefined) {
+      //this.context.textAlign="start"; 
+      this.context.fillStyle = "#000";
+      var oldTextBaseline = this.context.textBaseline;
+      this.context.textAlign="center";
+      this.context.textBaseline = 'middle';
+      this.context.fillText(this.messageShort, this.x, this.y); 
+      this.context.textBaseline = oldTextBaseline;
     }
 
     // Message


### PR DESCRIPTION
Add ability to put some text in the commit bubble. 
![image](https://user-images.githubusercontent.com/1269679/42344482-78786a8e-806a-11e8-910a-c8228363079a.png)

I'm using this to generate some docs and find it useful for referring to commits.
