### PR TITLE
Add dotFont option and a default for it.

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -626,6 +626,7 @@
    * @property {string} [tagFont = this.template.commit.tag.font] - Font of the tag
    * @property {string} [displayTagBox = true] - If true, display a box around the tag
    *
+   * @property {string} [fotFont = this.template.commit.dot.font] - Font of the dot
    * @property {string} [dotColor = color] - Specific dot color
    * @property {number} [dotSize = this.template.commit.dot.size] - Dot size
    * @property {number} [dotStrokeWidth = this.template.commit.dot.strokeWidth] - Dot stroke width
@@ -1046,6 +1047,8 @@
    * @param {string} [options.tagFont = this.template.commit.tag.font] - Font of the tag
    * @param {string} [options.displayTagBox = true] - If true, display a box around the tag
    *
+
+   * @param {string} [options.dotFont = this.template.commit.dot.font] - Font of the dot
    * @param {string} [options.dotColor = options.color] - Specific dot color
    * @param {number} [options.dotSize = this.template.commit.dot.size] - Dot size
    * @param {number} [options.dotStrokeWidth = this.template.commit.dot.strokeWidth] - Dot stroke width
@@ -1095,6 +1098,7 @@
     this.messageHashDisplay = _booleanOptionOr(options.messageHashDisplay, this.template.commit.message.displayHash);
     this.messageColor = options.messageColor || options.color;
     this.messageFont = options.messageFont || this.template.commit.message.font;
+    this.dotFont = options.dotFont || this.template.commit.dot.font;
     this.dotColor = options.dotColor || options.color;
     this.dotSize = options.dotSize || this.template.commit.dot.size;
     this.dotStrokeWidth = options.dotStrokeWidth || this.template.commit.dot.strokeWidth;
@@ -1212,6 +1216,7 @@
       var previousTextBaseline = this.context.textBaseline;
       var previousTextAlign = this.context.textAlign;
 
+      this.context.font = this.dotFont;
       this.context.fillStyle = "#000";
       this.context.textAlign = "center";
       this.context.textBaseline = "middle";
@@ -1392,6 +1397,7 @@
    * @param {number} [options.commit.spacingY] - Space between commits
    * @param {number} [options.commit.widthExtension = 0]  - Additional width to be added to the calculated width
    * @param {string} [options.commit.color] - Master commit color (dot & message)
+   * @param {string} [options.commit.dot.font] - Commit dot color
    * @param {string} [options.commit.dot.color] - Commit dot color
    * @param {number} [options.commit.dot.size] - Commit dot size
    * @param {number} [options.commit.dot.strokeWidth] - Commit dot stroke width
@@ -1466,6 +1472,7 @@
     this.commit.dot = {};
 
     // Only one color, if null message takes branch color (only dot)
+    this.commit.dot.font = options.commit.dot.font || "normal 10pt Calibri";
     this.commit.dot.color = options.commit.dot.color || null;
     this.commit.dot.size = options.commit.dot.size || 3;
     this.commit.dot.strokeWidth = options.commit.dot.strokeWidth || null;

--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -626,7 +626,7 @@
    * @property {string} [tagFont = this.template.commit.tag.font] - Font of the tag
    * @property {string} [displayTagBox = true] - If true, display a box around the tag
    *
-   * @property {string} [fotFont = this.template.commit.dot.font] - Font of the dot
+   * @property {string} [dotFont = this.template.commit.dot.font] - Font of the dot
    * @property {string} [dotColor = color] - Specific dot color
    * @property {number} [dotSize = this.template.commit.dot.size] - Dot size
    * @property {number} [dotStrokeWidth = this.template.commit.dot.strokeWidth] - Dot stroke width


### PR DESCRIPTION
If the dot text is used, it is not drawn with the correct value. The first commit uses some defaults, then font changes according to message font.

This patch solves it, adding config option 'font' and 'dotFont' for commit/merge.