### PR TITLE
Add commit object to the mouseEventOptions object

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -390,7 +390,8 @@
         author: commit.author,
         message: commit.message,
         date: commit.date,
-        sha1: commit.sha1
+        sha1: commit.sha1,
+        commit: commit
       };
 
       _emitEvent(self.canvas, "commit:" + event, mouseEventOptions);


### PR DESCRIPTION
This will allow users to work with the full commit object during mouse over and mouse out events