### PR TITLE
fix arrow color problem 

### DIFF
--- a/src/gitgraph.js
+++ b/src/gitgraph.js
@@ -1288,7 +1288,9 @@
       }
 
       alpha = rotate(alphaY, alphaX);
-      color = this.parentCommit.branch.color;
+      if (this.type != null ){
+        color = this.parentCommit.branch.color;
+      }
     }
 
     var delta = Math.PI / 7; // Delta between left & right (radian)


### PR DESCRIPTION
The color of some arrow was not the same color of stroke with it.
[before]
![Imgur](https://i.imgur.com/aOpNVlx.png)

So, this problem will be fixed.
[after]
![Imgur](https://i.imgur.com/0wSjU3G.png)