### PR TITLE
React/branches labels

### DIFF
--- a/packages/gitgraph-core/src/__tests__/branch.test.ts
+++ b/packages/gitgraph-core/src/__tests__/branch.test.ts
@@ -83,4 +83,34 @@ describe("Branch", () => {
       expect(mergeCommit.parents.length).toBe(2);
     });
   });
+
+  it("should fallback on template style for non-provided keys", () => {
+    const core = new GitgraphCore();
+    const gitgraph = core.getUserApi();
+
+    gitgraph.branch({ name: "master", style: {} });
+    const master = core.branches.get("master");
+
+    expect(Object.keys(master.style).length).not.toBe(0);
+  });
+
+  it("should fallback on template style of label for non-provided keys", () => {
+    const core = new GitgraphCore();
+    const gitgraph = core.getUserApi();
+
+    gitgraph.branch({ name: "master", style: { label: {} } });
+    const master = core.branches.get("master");
+
+    expect(Object.keys(master.style.label).length).not.toBe(0);
+  });
+
+  it("should override template style for provided keys", () => {
+    const core = new GitgraphCore();
+    const gitgraph = core.getUserApi();
+
+    gitgraph.branch({ name: "master", style: { spacing: 12345 } });
+    const master = core.branches.get("master");
+
+    expect(master.style.spacing).toBe(12345);
+  });
 });

--- a/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.style.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.style.test.ts
@@ -295,7 +295,6 @@ function createExpectedStyle() {
       color: "#979797",
       display: true,
       displayAuthor: true,
-      displayBranch: true,
       displayHash: true,
       font: "normal 14pt Arial",
     },

--- a/packages/gitgraph-core/src/gitgraph.ts
+++ b/packages/gitgraph-core/src/gitgraph.ts
@@ -151,7 +151,19 @@ class GitgraphCore<TNode = SVGElement> {
     if (typeof args === "string") {
       options.name = args;
     } else {
-      options = { ...options, ...args };
+      args.style = args.style || {};
+      options = {
+        ...options,
+        ...args,
+        style: {
+          ...options.style,
+          ...args.style,
+          label: {
+            ...options.style.label,
+            ...args.style.label,
+          },
+        },
+      };
     }
     const branch = new Branch<TNode>(options);
     this.branches.set(branch.name, branch);

--- a/packages/gitgraph-core/src/gitgraph.ts
+++ b/packages/gitgraph-core/src/gitgraph.ts
@@ -77,14 +77,8 @@ class GitgraphCore<TNode = SVGElement> {
     // Set all options with default values
     this.orientation = options.orientation;
     this.reverseArrow = booleanOptionOr(options.reverseArrow, false);
-    this.initCommitOffsetX = numberOptionOr(
-      options.initCommitOffsetX,
-      0,
-    ) as number;
-    this.initCommitOffsetY = numberOptionOr(
-      options.initCommitOffsetY,
-      0,
-    ) as number;
+    this.initCommitOffsetX = numberOptionOr(options.initCommitOffsetX, 0);
+    this.initCommitOffsetY = numberOptionOr(options.initCommitOffsetY, 0);
     this.mode = options.mode;
     this.author = options.author || "Sergio Flores <saxo-guy@epic.com>";
     this.commitMessage =

--- a/packages/gitgraph-core/src/template.ts
+++ b/packages/gitgraph-core/src/template.ts
@@ -140,10 +140,6 @@ interface CommitMessageStyle {
    */
   displayAuthor: boolean;
   /**
-   * Commit message branch display policy
-   */
-  displayBranch: boolean;
-  /**
    * Commit message hash display policy
    */
   displayHash: boolean;
@@ -294,10 +290,6 @@ class Template {
         display: booleanOptionOr(options.commit.message.display, true),
         displayAuthor: booleanOptionOr(
           options.commit.message.displayAuthor,
-          true,
-        ),
-        displayBranch: booleanOptionOr(
-          options.commit.message.displayBranch,
           true,
         ),
         displayHash: booleanOptionOr(options.commit.message.displayHash, true),

--- a/packages/gitgraph-core/src/template.ts
+++ b/packages/gitgraph-core/src/template.ts
@@ -64,9 +64,38 @@ interface BranchStyle {
    * Space between branches
    */
   spacing: number;
+  /**
+   * Branch label style
+   */
+  label: BranchLabelStyleOptions;
 }
 
 type BranchStyleOptions = Partial<BranchStyle>;
+
+interface BranchLabelStyle {
+  /**
+   * Branch label text color
+   */
+  color: string;
+  /**
+   * Branch label stroke color
+   */
+  strokeColor: string;
+  /**
+   * Branch label background color
+   */
+  bgColor: string;
+  /**
+   * Branch label font
+   */
+  font: string;
+  /**
+   * Branch label border radius
+   */
+  borderRadius: number;
+}
+
+type BranchLabelStyleOptions = Partial<BranchLabelStyle>;
 
 interface CommitDotStyle {
   /**
@@ -204,6 +233,7 @@ class Template {
   constructor(options: TemplateOptions) {
     // Options
     options.branch = options.branch || {};
+    options.branch.label = options.branch.label || {};
     options.arrow = options.arrow || {};
     options.commit = options.commit || {};
     options.commit.dot = options.commit.dot || {};
@@ -218,6 +248,16 @@ class Template {
       lineWidth: options.branch.lineWidth || 2,
       mergeStyle: options.branch.mergeStyle || MergeStyle.Bezier,
       spacing: numberOptionOr(options.branch.spacing, 20),
+      label: {
+        color: options.branch.label.color || options.commit.color,
+        strokeColor: options.branch.label.strokeColor || options.commit.color,
+        bgColor: options.branch.label.bgColor || "white",
+        font:
+          options.branch.label.font ||
+          options.commit.message.font ||
+          "normal 12pt Calibri",
+        borderRadius: numberOptionOr(options.branch.label.borderRadius, 10),
+      },
     };
 
     // Arrow style

--- a/packages/gitgraph-core/src/template.ts
+++ b/packages/gitgraph-core/src/template.ts
@@ -74,6 +74,10 @@ type BranchStyleOptions = Partial<BranchStyle>;
 
 interface BranchLabelStyle {
   /**
+   * Branch label visibility
+   */
+  display: boolean;
+  /**
    * Branch label text color
    */
   color: string;
@@ -249,6 +253,7 @@ class Template {
       mergeStyle: options.branch.mergeStyle || MergeStyle.Bezier,
       spacing: numberOptionOr(options.branch.spacing, 20),
       label: {
+        display: booleanOptionOr(options.branch.label.display, true),
         color: options.branch.label.color || options.commit.color,
         strokeColor: options.branch.label.strokeColor || options.commit.color,
         bgColor: options.branch.label.bgColor || "white",

--- a/packages/gitgraph-core/src/template.ts
+++ b/packages/gitgraph-core/src/template.ts
@@ -217,7 +217,7 @@ class Template {
       color: options.branch.color,
       lineWidth: options.branch.lineWidth || 2,
       mergeStyle: options.branch.mergeStyle || MergeStyle.Bezier,
-      spacing: numberOptionOr(options.branch.spacing, 20) as number,
+      spacing: numberOptionOr(options.branch.spacing, 20),
     };
 
     // Arrow style
@@ -230,7 +230,7 @@ class Template {
     // Commit style
     this.commit = {
       color: options.commit.color,
-      spacing: numberOptionOr(options.commit.spacing, 25) as number,
+      spacing: numberOptionOr(options.commit.spacing, 25),
       hasTooltipInCompactMode: booleanOptionOr(
         options.commit.hasTooltipInCompactMode,
         true,
@@ -238,10 +238,7 @@ class Template {
       dot: {
         color: options.commit.dot.color || options.commit.color,
         size: options.commit.dot.size || 3,
-        strokeWidth: numberOptionOr(
-          options.commit.dot.strokeWidth,
-          0,
-        ) as number,
+        strokeWidth: numberOptionOr(options.commit.dot.strokeWidth, 0),
         strokeColor: options.commit.dot.strokeColor,
         font:
           options.commit.dot.font ||

--- a/packages/gitgraph-core/src/utils.ts
+++ b/packages/gitgraph-core/src/utils.ts
@@ -51,10 +51,7 @@ function booleanOptionOr(value: any, defaultValue: boolean): boolean {
  * @param value
  * @param defaultValue
  */
-function numberOptionOr(
-  value: any,
-  defaultValue: number | null,
-): number | null {
+function numberOptionOr(value: any, defaultValue: number): number {
   return typeof value === "number" ? value : defaultValue;
 }
 

--- a/packages/gitgraph-react/src/BranchLabel.tsx
+++ b/packages/gitgraph-react/src/BranchLabel.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import { Commit } from "@gitgraph/core";
+import { Branch, Commit } from "@gitgraph/core";
 
 interface Props {
+  branch: Branch<React.ReactElement<SVGElement>>;
   commit: Commit<React.ReactElement<SVGElement>>;
   x: number;
   y: number;
@@ -25,32 +26,29 @@ export class BranchLabel extends React.Component<Props, State> {
   }
 
   public render() {
-    const { commit, x, y } = this.props;
+    const { branch, commit, x, y } = this.props;
 
-    const radius = 10;
-    const bgColor = "white";
     const boxWidth = this.state.textWidth + 2 * BranchLabel.paddingX;
     const boxHeight = this.state.textHeight + 2 * BranchLabel.paddingY;
 
     return (
       <g transform={`translate(${x}, ${y})`}>
         <rect
-          // TODO: re-introduce branch label style options
-          stroke={commit.style.color}
-          fill={bgColor}
-          rx={radius}
+          stroke={branch.style.label.strokeColor || commit.style.color}
+          fill={branch.style.label.bgColor}
+          rx={branch.style.label.borderRadius}
           width={boxWidth}
           height={boxHeight}
         />
         <text
           ref={this.$text}
-          fill={commit.style.color}
-          style={{ font: commit.style.message.font }}
+          fill={branch.style.label.color || commit.style.color}
+          style={{ font: branch.style.label.font }}
           alignmentBaseline="middle"
           x={BranchLabel.paddingX}
           y={boxHeight / 2}
         >
-          {commit.branchToDisplay}
+          {branch.name}
         </text>
       </g>
     );

--- a/packages/gitgraph-react/src/BranchLabel.tsx
+++ b/packages/gitgraph-react/src/BranchLabel.tsx
@@ -3,6 +3,8 @@ import { Commit } from "@gitgraph/core";
 
 interface Props {
   commit: Commit<React.ReactElement<SVGElement>>;
+  x: number;
+  y: number;
 }
 
 interface State {
@@ -23,7 +25,7 @@ export class BranchLabel extends React.Component<Props, State> {
   }
 
   public render() {
-    const { commit } = this.props;
+    const { commit, x, y } = this.props;
 
     const radius = 10;
     const bgColor = "white";
@@ -31,7 +33,7 @@ export class BranchLabel extends React.Component<Props, State> {
     const boxHeight = this.state.textHeight + 2 * BranchLabel.paddingY;
 
     return (
-      <>
+      <g transform={`translate(${x}, ${y})`}>
         <rect
           // TODO: re-introduce branch label style options
           stroke={commit.style.color}
@@ -50,7 +52,7 @@ export class BranchLabel extends React.Component<Props, State> {
         >
           {commit.branchToDisplay}
         </text>
-      </>
+      </g>
     );
   }
 }

--- a/packages/gitgraph-react/src/BranchLabel.tsx
+++ b/packages/gitgraph-react/src/BranchLabel.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import { Commit } from "@gitgraph/core";
+
+interface Props {
+  name: string;
+  commit: Commit<React.ReactElement<SVGElement>>;
+}
+
+interface State {
+  textWidth: number;
+  textHeight: number;
+}
+
+export class BranchLabel extends React.Component<Props, State> {
+  public static readonly paddingX = 10;
+  public static readonly paddingY = 5;
+  public readonly state = { textWidth: 0, textHeight: 0 };
+
+  private $text = React.createRef<SVGTextElement>();
+
+  public componentDidMount() {
+    const box = this.$text.current!.getBBox();
+    this.setState({ textWidth: box.width, textHeight: box.height });
+  }
+
+  public render() {
+    const { commit, name } = this.props;
+
+    const radius = 10;
+    const bgColor = "white";
+    const boxWidth = this.state.textWidth + 2 * BranchLabel.paddingX;
+    const boxHeight = this.state.textHeight + 2 * BranchLabel.paddingY;
+
+    return (
+      <>
+        <rect
+          // TODO: re-introduce branch label style options
+          stroke={commit.style.color}
+          fill={bgColor}
+          rx={radius}
+          width={boxWidth}
+          height={boxHeight}
+        />
+        <text
+          ref={this.$text}
+          fill={commit.style.color}
+          style={{ font: commit.style.message.font }}
+          alignmentBaseline="middle"
+          x={BranchLabel.paddingX}
+          y={boxHeight / 2}
+        >
+          {name}
+        </text>
+      </>
+    );
+  }
+}

--- a/packages/gitgraph-react/src/BranchLabel.tsx
+++ b/packages/gitgraph-react/src/BranchLabel.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { Commit } from "@gitgraph/core";
 
 interface Props {
-  name: string;
   commit: Commit<React.ReactElement<SVGElement>>;
 }
 
@@ -24,7 +23,7 @@ export class BranchLabel extends React.Component<Props, State> {
   }
 
   public render() {
-    const { commit, name } = this.props;
+    const { commit } = this.props;
 
     const radius = 10;
     const bgColor = "white";
@@ -49,7 +48,7 @@ export class BranchLabel extends React.Component<Props, State> {
           x={BranchLabel.paddingX}
           y={boxHeight / 2}
         >
-          {name}
+          {commit.branchToDisplay}
         </text>
       </>
     );

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -127,14 +127,11 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
       );
     }
 
-    if (this.$commits.current) {
-      this.translateCommitMessages(Array.from(this.$commits.current.children));
-    }
-
     if (!this.state.shouldRecomputeOffsets) return;
     if (!this.$commits.current) return;
 
     const commits = this.$commits.current.children;
+    this.translateCommitMessages(Array.from(commits));
     this.setState({
       commitYWithOffsets: this.computeOffsets(commits),
       shouldRecomputeOffsets: false,

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -162,37 +162,34 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
 
   private renderBranchesLabels() {
     const branches = Array.from(this.gitgraph.branches.values());
-    return branches
-      .map((branch) => {
-        const commitHash = this.gitgraph.refs.getCommit(branch.name);
-        return this.state.commits.find(({ hash }) => commitHash === hash);
-      })
-      .filter(
-        (commit): commit is Commit<ReactSvgElement> => commit !== undefined,
-      )
-      .filter((commit) => commit.style.message.displayBranch)
-      .map((commit) => {
-        const ref = React.createRef<SVGGElement>();
+    return branches.map((branch) => {
+      const commitHash = this.gitgraph.refs.getCommit(branch.name);
+      const commit = this.state.commits.find(({ hash }) => commitHash === hash);
 
-        // Store the ref to adapt commit message position.
-        this.branchesLabels[commit.hashAbbrev] = ref;
+      if (!commit) return null;
+      if (!commit.style.message.displayBranch) return null;
 
-        const x = this.gitgraph.isVertical
-          ? this.state.commitMessagesX
-          : commit.x;
+      const ref = React.createRef<SVGGElement>();
 
-        const commitDotSize = commit.style.dot.size * 2;
-        const horizontalMarginTop = 10;
-        const y = this.gitgraph.isVertical
-          ? this.getMessageOffset(commit).y
-          : commit.y + commitDotSize + horizontalMarginTop;
+      // Store the ref to adapt commit message position.
+      this.branchesLabels[commit.hashAbbrev] = ref;
 
-        return (
-          <g key={commit.branchToDisplay} ref={ref}>
-            <BranchLabel commit={commit} x={x} y={y} />
-          </g>
-        );
-      });
+      const x = this.gitgraph.isVertical
+        ? this.state.commitMessagesX
+        : commit.x;
+
+      const commitDotSize = commit.style.dot.size * 2;
+      const horizontalMarginTop = 10;
+      const y = this.gitgraph.isVertical
+        ? this.getMessageOffset(commit).y
+        : commit.y + commitDotSize + horizontalMarginTop;
+
+      return (
+        <g key={branch.name} ref={ref}>
+          <BranchLabel branch={branch} commit={commit} x={x} y={y} />
+        </g>
+      );
+    });
   }
 
   private renderCommits() {

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -295,7 +295,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
   private renderMessage(commit: Commit<ReactSvgElement>) {
     if (commit.renderMessage) {
       return (
-        <g className="message" transform="translate(0, 0)">
+        <g className="message">
           {commit.renderMessage(commit, this.state.commitMessagesX)}
         </g>
       );

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -195,7 +195,6 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
       )
       .filter((commit) => commit.style.message.displayBranch)
       .map((commit) => {
-        const branch = commit.branchToDisplay;
         const ref = React.createRef<SVGGElement>();
 
         // Store the ref to adapt commit message position.
@@ -212,8 +211,12 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
           : commit.y + commitDotSize + horizontalMarginTop;
 
         return (
-          <g key={branch} ref={ref} transform={`translate(${x}, ${y})`}>
-            <BranchLabel commit={commit} name={branch} />
+          <g
+            key={commit.branchToDisplay}
+            ref={ref}
+            transform={`translate(${x}, ${y})`}
+          >
+            <BranchLabel commit={commit} />
           </g>
         );
       });

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -184,11 +184,6 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
   }
 
   private renderBranchesLabels() {
-    if (this.gitgraph.isHorizontal) {
-      // TODO: handle branch labels in horizontal mode
-      return null;
-    }
-
     const branches = Array.from(this.gitgraph.branches.values());
     return branches
       .map((branch) => {
@@ -203,11 +198,18 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
         const branch = commit.branchToDisplay;
         const ref = React.createRef<SVGGElement>();
 
-        const x = this.state.commitMessagesX;
-        const { y } = this.getMessageOffset(commit);
-
         // Store the ref to adapt commit message position.
         this.branchesLabels[commit.hashAbbrev] = ref;
+
+        const x = this.gitgraph.isVertical
+          ? this.state.commitMessagesX
+          : commit.x;
+
+        const commitDotSize = commit.style.dot.size * 2;
+        const horizontalMarginTop = 10;
+        const y = this.gitgraph.isVertical
+          ? this.getMessageOffset(commit).y
+          : commit.y + commitDotSize + horizontalMarginTop;
 
         return (
           <g key={branch} ref={ref} transform={`translate(${x}, ${y})`}>

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -133,7 +133,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
     if (!this.$commits.current) return;
 
     const commits = Array.from(this.$commits.current.children);
-    this.translateCommitMessages(commits);
+    this.translateCommitMessagesWithBranchLabel(commits);
     this.setState({
       commitYWithOffsets: this.computeOffsets(commits),
       shouldRecomputeOffsets: false,
@@ -339,7 +339,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
     );
   }
 
-  private translateCommitMessages(commits: Element[]): void {
+  private translateCommitMessagesWithBranchLabel(commits: Element[]): void {
     commits.forEach((commit) => {
       const branchLabel = this.branchesLabels[commit.id];
       if (!branchLabel || !branchLabel.current) {

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -96,8 +96,9 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
   public render() {
     return (
       <svg ref={this.$graph}>
+        {/* Translate graph left => left-most branch label is not cropped */}
         {/* Translate graph down => top-most commit tooltip is not cropped */}
-        <g transform={`translate(0, ${Tooltip.padding})`}>
+        <g transform={`translate(${BranchLabel.paddingX}, ${Tooltip.padding})`}>
           {this.renderBranchesPaths()}
           {this.renderBranchesLabels()}
           {this.renderCommits()}
@@ -116,14 +117,15 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
       const { height, width } = this.$graph.current.getBBox();
       this.$graph.current.setAttribute(
         "width",
-        // `width` crop the tooltip text without considering the `padding`.
-        (width + Tooltip.padding).toString(),
+        // Add `Tooltip.padding` so we don't crop the tooltip text.
+        // Add `BranchLabel.paddingX` so we don't cut branch label.
+        (width + Tooltip.padding + BranchLabel.paddingX).toString(),
       );
       this.$graph.current.setAttribute(
         "height",
-        // As we translate the graph by `Tooltip.padding`,
-        // we need to take it into account in height calculation too.
-        (height + Tooltip.padding + BranchLabel.paddingX).toString(),
+        // Add `Tooltip.padding` so we don't crop tooltip text
+        // Add `BranchLabel.paddingY` so we don't crop branch label.
+        (height + Tooltip.padding + BranchLabel.paddingY).toString(),
       );
     }
 

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -163,11 +163,11 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
   private renderBranchesLabels() {
     const branches = Array.from(this.gitgraph.branches.values());
     return branches.map((branch) => {
+      if (!branch.style.label.display) return null;
+
       const commitHash = this.gitgraph.refs.getCommit(branch.name);
       const commit = this.state.commits.find(({ hash }) => commitHash === hash);
-
       if (!commit) return null;
-      if (!commit.style.message.displayBranch) return null;
 
       const ref = React.createRef<SVGGElement>();
 

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -128,29 +128,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
     }
 
     if (this.$commits.current) {
-      Array.from(this.$commits.current.children).forEach((commit) => {
-        const branchLabel = this.branchesLabels[commit.id];
-        if (!branchLabel || !branchLabel.current) {
-          return;
-        }
-
-        // Here we rely on the .message class name. A ref might be better.
-        const message = commit.getElementsByClassName("message")[0];
-        if (!message) return;
-
-        const matches = message
-          .getAttribute("transform")!
-          .match(/translate\((\d+),\s(\d+)\)/);
-        if (!matches) return;
-
-        const [, x, y] = matches.map((a) => parseInt(a, 10));
-        // For some reason, 1 padding is not included in BBox total width.
-        const branchLabelWidth =
-          branchLabel.current.getBBox().width + BranchLabel.paddingX;
-        const padding = 10;
-        const newX = x + branchLabelWidth + padding;
-        message.setAttribute("transform", `translate(${newX}, ${y})`);
-      });
+      this.translateCommitMessages(Array.from(this.$commits.current.children));
     }
 
     if (!this.state.shouldRecomputeOffsets) return;
@@ -360,6 +338,32 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
         />
       </g>
     );
+  }
+
+  private translateCommitMessages(commits: Element[]): void {
+    commits.forEach((commit) => {
+      const branchLabel = this.branchesLabels[commit.id];
+      if (!branchLabel || !branchLabel.current) {
+        return;
+      }
+
+      // Here we rely on the .message class name. A ref might be better.
+      const message = commit.getElementsByClassName("message")[0];
+      if (!message) return;
+
+      const matches = message
+        .getAttribute("transform")!
+        .match(/translate\((\d+),\s(\d+)\)/);
+      if (!matches) return;
+
+      const [, x, y] = matches.map((a) => parseInt(a, 10));
+      // For some reason, 1 padding is not included in BBox total width.
+      const branchLabelWidth =
+        branchLabel.current.getBBox().width + BranchLabel.paddingX;
+      const padding = 10;
+      const newX = x + branchLabelWidth + padding;
+      message.setAttribute("transform", `translate(${newX}, ${y})`);
+    });
   }
 
   private computeOffsets(

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -130,8 +130,8 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
     if (!this.state.shouldRecomputeOffsets) return;
     if (!this.$commits.current) return;
 
-    const commits = this.$commits.current.children;
-    this.translateCommitMessages(Array.from(commits));
+    const commits = Array.from(this.$commits.current.children);
+    this.translateCommitMessages(commits);
     this.setState({
       commitYWithOffsets: this.computeOffsets(commits),
       shouldRecomputeOffsets: false,
@@ -364,15 +364,15 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
   }
 
   private computeOffsets(
-    commits: HTMLCollection,
+    commits: Element[],
   ): GitgraphState["commitYWithOffsets"] {
     let totalOffsetY = 0;
 
     // In VerticalReverse orientation, commits are in the same order in the DOM.
     const orientedCommits =
       this.gitgraph.orientation === Orientation.VerticalReverse
-        ? Array.from(commits)
-        : Array.from(commits).reverse();
+        ? commits
+        : commits.reverse();
 
     return orientedCommits.reduce<GitgraphState["commitYWithOffsets"]>(
       (newOffsets, commit) => {

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -211,12 +211,8 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
           : commit.y + commitDotSize + horizontalMarginTop;
 
         return (
-          <g
-            key={commit.branchToDisplay}
-            ref={ref}
-            transform={`translate(${x}, ${y})`}
-          >
-            <BranchLabel commit={commit} />
+          <g key={commit.branchToDisplay} ref={ref}>
+            <BranchLabel commit={commit} x={x} y={y} />
           </g>
         );
       });

--- a/packages/gitgraph-react/src/stories/5-templates.stories.tsx
+++ b/packages/gitgraph-react/src/stories/5-templates.stories.tsx
@@ -92,17 +92,17 @@ storiesOf("5. Templates", module)
       </Gitgraph>
     );
   })
-  .add("without commit branch", () => {
-    const withoutBranch = templateExtend(TemplateName.Metro, {
-      commit: {
-        message: {
-          displayBranch: false,
+  .add("without branch label", () => {
+    const withoutBranchLabel = templateExtend(TemplateName.Metro, {
+      branch: {
+        label: {
+          display: false,
         },
       },
     });
 
     return (
-      <Gitgraph options={{ template: withoutBranch }}>
+      <Gitgraph options={{ template: withoutBranchLabel }}>
         {(gitgraph) => {
           gitgraph
             .commit("one")

--- a/packages/gitgraph-react/src/stories/5-templates.stories.tsx
+++ b/packages/gitgraph-react/src/stories/5-templates.stories.tsx
@@ -103,4 +103,28 @@ storiesOf("5. Templates", module)
           .commit("three");
       }}
     </Gitgraph>
-  ));
+  ))
+  .add("with custom branch labels", () => {
+    const customBranchLabels = templateExtend(TemplateName.Metro, {
+      branch: {
+        label: {
+          bgColor: "#ffce52",
+          color: "black",
+          strokeColor: "#ce9b00",
+          borderRadius: 0,
+          font: "italic 12pt serif",
+        },
+      },
+    });
+
+    return (
+      <Gitgraph options={{ template: customBranchLabels }}>
+        {(gitgraph) => {
+          gitgraph
+            .commit("one")
+            .commit("two")
+            .commit("three");
+        }}
+      </Gitgraph>
+    );
+  });

--- a/packages/gitgraph-react/src/stories/5-templates.stories.tsx
+++ b/packages/gitgraph-react/src/stories/5-templates.stories.tsx
@@ -3,28 +3,6 @@ import { storiesOf } from "@storybook/react";
 
 import { Gitgraph, templateExtend, TemplateName } from "../Gitgraph";
 
-const templateWithoutHash = templateExtend(TemplateName.Metro, {
-  commit: {
-    message: {
-      displayHash: false,
-    },
-  },
-});
-const templateWithoutAuthor = templateExtend(TemplateName.Metro, {
-  commit: {
-    message: {
-      displayAuthor: false,
-    },
-  },
-});
-const templateWithoutBranch = templateExtend(TemplateName.Metro, {
-  commit: {
-    message: {
-      displayBranch: false,
-    },
-  },
-});
-
 storiesOf("5. Templates", module)
   .add("metro", () => (
     <Gitgraph options={{ template: TemplateName.Metro }}>
@@ -74,36 +52,66 @@ storiesOf("5. Templates", module)
       }}
     </Gitgraph>
   ))
-  .add("without commit hash", () => (
-    <Gitgraph options={{ template: templateWithoutHash }}>
-      {(gitgraph) => {
-        gitgraph
-          .commit("one")
-          .commit("two")
-          .commit("three");
-      }}
-    </Gitgraph>
-  ))
-  .add("without commit author", () => (
-    <Gitgraph options={{ template: templateWithoutAuthor }}>
-      {(gitgraph) => {
-        gitgraph
-          .commit("one")
-          .commit("two")
-          .commit("three");
-      }}
-    </Gitgraph>
-  ))
-  .add("without commit branch", () => (
-    <Gitgraph options={{ template: templateWithoutBranch }}>
-      {(gitgraph) => {
-        gitgraph
-          .commit("one")
-          .commit("two")
-          .commit("three");
-      }}
-    </Gitgraph>
-  ))
+  .add("without commit hash", () => {
+    const withoutHash = templateExtend(TemplateName.Metro, {
+      commit: {
+        message: {
+          displayHash: false,
+        },
+      },
+    });
+
+    return (
+      <Gitgraph options={{ template: withoutHash }}>
+        {(gitgraph) => {
+          gitgraph
+            .commit("one")
+            .commit("two")
+            .commit("three");
+        }}
+      </Gitgraph>
+    );
+  })
+  .add("without commit author", () => {
+    const withoutAuthor = templateExtend(TemplateName.Metro, {
+      commit: {
+        message: {
+          displayAuthor: false,
+        },
+      },
+    });
+
+    return (
+      <Gitgraph options={{ template: withoutAuthor }}>
+        {(gitgraph) => {
+          gitgraph
+            .commit("one")
+            .commit("two")
+            .commit("three");
+        }}
+      </Gitgraph>
+    );
+  })
+  .add("without commit branch", () => {
+    const withoutBranch = templateExtend(TemplateName.Metro, {
+      commit: {
+        message: {
+          displayBranch: false,
+        },
+      },
+    });
+
+    return (
+      <Gitgraph options={{ template: withoutBranch }}>
+        {(gitgraph) => {
+          gitgraph
+            .commit("one")
+            .commit("two")
+            .commit("three");
+        }}
+      </Gitgraph>
+    );
+  })
   .add("with custom branch labels", () => {
     const customBranchLabels = templateExtend(TemplateName.Metro, {
       branch: {


### PR DESCRIPTION
Fixes #221 

Also, I realized that it will:
- Fix #160 (branch names display on the last commit of the branch) 
- Fix #142 (branch names display in compact mode, pointing to the commit)

## Default

![image](https://user-images.githubusercontent.com/1094774/53853719-9fc97300-3f94-11e9-88ab-facdd700d04e.png)

## Vertical reverse

![image](https://user-images.githubusercontent.com/1094774/53853723-a5bf5400-3f94-11e9-8e84-1959a7609758.png)

## Horizontal

![image](https://user-images.githubusercontent.com/1094774/53853726-a952db00-3f94-11e9-8f94-5bf411e1e5fd.png)

## Horizontal reverse

![image](https://user-images.githubusercontent.com/1094774/53853734-ad7ef880-3f94-11e9-9013-61fe985a1245.png)

## Blackarrow

![image](https://user-images.githubusercontent.com/1094774/53853740-b2dc4300-3f94-11e9-95b3-37e9c30aedec.png)

## Custom

![image](https://user-images.githubusercontent.com/1094774/53856780-824ed600-3fa1-11e9-8cbb-e31bf349d28c.png)
