### PR TITLE
Fix live update labels position

### DIFF
--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -89,7 +89,12 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
     this.gitgraph = new GitgraphCore<ReactSvgElement>(props.options);
     this.gitgraph.subscribe((data) => {
       const { commits, branchesPaths, commitMessagesX } = data;
-      this.setState({ commits, branchesPaths, commitMessagesX });
+      this.setState({
+        commits,
+        branchesPaths,
+        commitMessagesX,
+        shouldRecomputeOffsets: true,
+      });
     });
   }
 


### PR DESCRIPTION
Just spot a little bug on the `playground` story:
When we commit on a rendered graph, labels are not correctly computed.

## Before

![image](https://user-images.githubusercontent.com/1761469/53973368-e805a400-4100-11e9-9667-8d70644f91c7.png)

## After

![image](https://user-images.githubusercontent.com/1761469/53973388-f18f0c00-4100-11e9-9a94-0c4d3a43091d.png)
