### PR TITLE
Fix commit message body visibility

### DIFF
--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -401,6 +401,11 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
           ? customHtmlMessage.getBoundingClientRect().height
           : 0;
 
+        // Force the height of the foreignObject (browser issue)
+        if (firstForeignObject) {
+          firstForeignObject.setAttribute("height", `${messageHeight}px`);
+        }
+
         newOffsets[commitY] = commitY + totalOffsetY;
 
         // Increment total offset after setting the offset


### PR DESCRIPTION
For a very strange reason, we need to have the `height` explicit to see the message on the DOM ¯\_(ツ)_/¯

## Before
![image](https://user-images.githubusercontent.com/1761469/53975426-11283380-4105-11e9-9d70-93b112f7d256.png)

## After
![image](https://user-images.githubusercontent.com/1761469/53975266-bee71280-4104-11e9-9309-bc92e8d22972.png)
