### PR TITLE
Fix and improve the `translateCommitMessagesWithBranchLabel` strategy

### DIFF
--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -356,18 +356,21 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
       const message = commit.getElementsByClassName("message")[0];
       if (!message) return;
 
-      const matches = message
-        .getAttribute("transform")!
-        .match(/translate\((\d+),\s(\d+)\)/);
+      const transformAttribute =
+        message.getAttribute("transform") || "translate(0, 0)";
+      const matches = transformAttribute.match(/translate\((\d+),/);
       if (!matches) return;
 
-      const [, x, y] = matches.map((a) => parseInt(a, 10));
+      const [, x] = matches.map((a) => parseInt(a, 10));
       // For some reason, 1 padding is not included in BBox total width.
       const branchLabelWidth =
         branchLabel.current.getBBox().width + BranchLabel.paddingX;
       const padding = 10;
       const newX = x + branchLabelWidth + padding;
-      message.setAttribute("transform", `translate(${newX}, ${y})`);
+      message.setAttribute(
+        "transform",
+        transformAttribute.replace(/translate\((\d+),/, `translate(${newX},`),
+      );
     });
   }
 


### PR DESCRIPTION
In `translateCommitMessagesWithBranchLabel`, `message.getAttribute("transform")` can be null in custom message render cases. This PR fix these edge cases.

## 6. Custom Render / with render message (after fix)

![image](https://user-images.githubusercontent.com/1761469/53981014-0c1db100-4112-11e9-842d-15f0354557cc.png)
