### PR TITLE
Customize Tag style

### DIFF
--- a/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.tags.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.tags.test.ts
@@ -1,4 +1,5 @@
 import { GitgraphCore } from "../gitgraph";
+import { Tag } from "../tag";
 
 describe("Gitgraph.getRenderedData.tags", () => {
   it("should tag a commit", () => {
@@ -12,11 +13,8 @@ describe("Gitgraph.getRenderedData.tags", () => {
 
     const { commits } = core.getRenderedData();
 
-    expect(commits).toMatchObject([
-      { subject: "one" },
-      { subject: "with tag", tags: ["1.0.0"] },
-      { subject: "three" },
-    ]);
+    expect(commits[1].tags.length).toBe(1);
+    expect(commits[1].tags[0].name).toBe("1.0.0");
   });
 
   it("should tag the last commit of the branch", () => {

--- a/packages/gitgraph-core/src/__tests__/gitgraph.import.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.import.test.ts
@@ -115,16 +115,9 @@ describe("Gitgraph.import", () => {
     gitgraph.import(data);
 
     const { commits } = core.getRenderedData();
-    expect(commits).toMatchObject([
-      {
-        subject: "first",
-        tags: ["stable"],
-      },
-      {
-        subject: "second",
-        tags: ["v1.0"],
-      },
-    ]);
+
+    expect(commits[0].tags[0].name).toBe("stable");
+    expect(commits[1].tags[0].name).toBe("v1.0");
   });
 
   it("should not put tags in refs", () => {

--- a/packages/gitgraph-core/src/__tests__/gitgraph.tag.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.tag.test.ts
@@ -62,11 +62,11 @@ describe("Gitgraph.tag", () => {
 
     const { commits } = core.getRenderedData();
 
-    expect(commits).toMatchObject([
-      { subject: "one", tags: [] },
-      { subject: "two", tags: [] },
-      { subject: "three", tags: [] },
-      { subject: "four-tagged", tags: ["tag-one", "tag-two"] },
-    ]);
+    expect(commits[0].tags.length).toBe(0);
+    expect(commits[1].tags.length).toBe(0);
+    expect(commits[2].tags.length).toBe(0);
+    expect(commits[3].tags.length).toBe(2);
+    expect(commits[3].tags[0].name).toBe("tag-one");
+    expect(commits[3].tags[1].name).toBe("tag-two");
   });
 });

--- a/packages/gitgraph-core/src/__tests__/gitgraph.tag.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.tag.test.ts
@@ -43,6 +43,28 @@ describe("Gitgraph.tag", () => {
     expect(core.tags.getCommit("this-one")).toEqual("tagged-hash");
   });
 
+  it("should tag a branch directly", () => {
+    const core = new GitgraphCore();
+    const gitgraph = core.getUserApi();
+
+    const dev = gitgraph.branch("dev");
+    dev.commit({ subject: "tagged", hash: "tagged-hash" });
+    dev.tag("this-one");
+
+    expect(core.tags.getCommit("this-one")).toEqual("tagged-hash");
+  });
+
+  it("should tag a branch directly with options param", () => {
+    const core = new GitgraphCore();
+    const gitgraph = core.getUserApi();
+
+    const dev = gitgraph.branch("dev");
+    dev.commit({ subject: "tagged", hash: "tagged-hash" });
+    dev.tag({ name: "this-one" });
+
+    expect(core.tags.getCommit("this-one")).toEqual("tagged-hash");
+  });
+
   it("should add a tag to HEAD", () => {
     const core = new GitgraphCore();
     const gitgraph = core.getUserApi();

--- a/packages/gitgraph-core/src/__tests__/gitgraph.tag.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.tag.test.ts
@@ -84,6 +84,27 @@ describe("Gitgraph.tag", () => {
     expect(core.tags.getCommit("this-one")).toEqual("tagged-hash");
   });
 
+  it("should add a tag to a branch with style", () => {
+    const core = new GitgraphCore();
+    const gitgraph = core.getUserApi();
+    const tagStyle = {
+      color: "black",
+      strokeColor: "#ce9b00",
+      bgColor: "#ffce52",
+      font: "italic 12pt serif",
+      borderRadius: 0,
+      pointerWidth: 6,
+    };
+
+    gitgraph
+      .branch("dev")
+      .commit({ subject: "tagged", hash: "tagged-hash" })
+      .tag({ name: "this-one", style: tagStyle });
+    const { commits } = core.getRenderedData();
+
+    expect(commits[0].tags[0].style).toEqual(tagStyle);
+  });
+
   it("should add a tag to HEAD", () => {
     const core = new GitgraphCore();
     const gitgraph = core.getUserApi();

--- a/packages/gitgraph-core/src/__tests__/gitgraph.tag.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.tag.test.ts
@@ -18,6 +18,25 @@ describe("Gitgraph.tag", () => {
     expect(core.tags.getCommit("this-one")).toEqual("one-tagged-hash");
   });
 
+  it("should add a tag to a commit with style", () => {
+    const core = new GitgraphCore();
+    const gitgraph = core.getUserApi();
+    const tagStyle = {
+      color: "black",
+      strokeColor: "#ce9b00",
+      bgColor: "#ffce52",
+      font: "italic 12pt serif",
+      borderRadius: 0,
+      pointerWidth: 6,
+    };
+
+    gitgraph.branch("dev").commit({ subject: "tagged", hash: "tagged-hash" });
+    gitgraph.tag({ name: "this-one", ref: "tagged-hash", style: tagStyle });
+    const { commits } = core.getRenderedData();
+
+    expect(commits[0].tags[0].style).toEqual(tagStyle);
+  });
+
   it("should add a tag to a branch", () => {
     const core = new GitgraphCore();
     const gitgraph = core.getUserApi();

--- a/packages/gitgraph-core/src/__tests__/gitgraph.tag.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.tag.test.ts
@@ -33,6 +33,16 @@ describe("Gitgraph.tag", () => {
     expect(core.tags.getCommit("this-one")).toEqual("three-tagged-hash");
   });
 
+  it("should add a tag to a branch with options param", () => {
+    const core = new GitgraphCore();
+    const gitgraph = core.getUserApi();
+
+    gitgraph.branch("dev").commit({ subject: "tagged", hash: "tagged-hash" });
+    gitgraph.tag({ name: "this-one", ref: "dev" });
+
+    expect(core.tags.getCommit("this-one")).toEqual("tagged-hash");
+  });
+
   it("should add a tag to HEAD", () => {
     const core = new GitgraphCore();
     const gitgraph = core.getUserApi();

--- a/packages/gitgraph-core/src/__tests__/gitgraph.tag.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.tag.test.ts
@@ -80,6 +80,19 @@ describe("Gitgraph.tag", () => {
     expect(core.tags.getCommit("this-one")).toEqual("four-tagged-hash");
   });
 
+  it("should throw if given reference doesn't exist", () => {
+    const core = new GitgraphCore();
+    const gitgraph = core.getUserApi();
+
+    gitgraph
+      .branch("master")
+      .commit({ subject: "tagged", hash: "tagged-hash" });
+
+    expect(() => gitgraph.tag("this-one", "unknown")).toThrowError(
+      'The ref "unknown" does not exist',
+    );
+  });
+
   it("should add tags into render output", () => {
     const core = new GitgraphCore();
     const gitgraph = core.getUserApi();

--- a/packages/gitgraph-core/src/commit.ts
+++ b/packages/gitgraph-core/src/commit.ts
@@ -1,6 +1,7 @@
 import { CommitStyle } from "./template";
 import { Branch } from "./branch";
 import { Refs } from "./refs";
+import { Tag } from "./tag";
 
 export { CommitRenderOptions, CommitOptions, Commit };
 
@@ -137,7 +138,7 @@ class Commit<TNode = SVGElement> {
   /**
    * List of tags attached
    */
-  public tags?: string[];
+  public tags?: Tag[];
   /**
    * Callback to execute on click.
    */
@@ -219,8 +220,8 @@ class Commit<TNode = SVGElement> {
     return this;
   }
 
-  public setTags(tags: Refs): this {
-    this.tags = tags.getNames(this.hash);
+  public setTags(tags: Tag[]): this {
+    this.tags = tags;
     return this;
   }
 

--- a/packages/gitgraph-core/src/commit.ts
+++ b/packages/gitgraph-core/src/commit.ts
@@ -220,10 +220,13 @@ class Commit<TNode = SVGElement> {
     return this;
   }
 
-  public setTags(tags: Refs, tagStyle: Partial<TagStyle>): this {
+  public setTags(
+    tags: Refs,
+    getTagStyle: (name: Tag["name"]) => Partial<TagStyle>,
+  ): this {
     this.tags = tags
       .getNames(this.hash)
-      .map((name) => new Tag(name, tagStyle, this.style));
+      .map((name) => new Tag(name, getTagStyle(name), this.style));
     return this;
   }
 

--- a/packages/gitgraph-core/src/commit.ts
+++ b/packages/gitgraph-core/src/commit.ts
@@ -1,4 +1,4 @@
-import { CommitStyle } from "./template";
+import { CommitStyle, TagStyle } from "./template";
 import { Branch } from "./branch";
 import { Refs } from "./refs";
 import { Tag } from "./tag";
@@ -220,8 +220,10 @@ class Commit<TNode = SVGElement> {
     return this;
   }
 
-  public setTags(tags: Tag[]): this {
-    this.tags = tags;
+  public setTags(tags: Refs, tagStyle: Partial<TagStyle>): this {
+    this.tags = tags
+      .getNames(this.hash)
+      .map((name) => new Tag(name, tagStyle, this.style));
     return this;
   }
 

--- a/packages/gitgraph-core/src/gitgraph.ts
+++ b/packages/gitgraph-core/src/gitgraph.ts
@@ -5,7 +5,6 @@ import {
   BranchOptions,
 } from "./branch";
 import { Commit } from "./commit";
-import { Tag } from "./tag";
 import { createGraphRows } from "./graph-rows";
 import { GraphColumns } from "./graph-columns";
 import { Template, TemplateName, getTemplate } from "./template";
@@ -188,14 +187,7 @@ class GitgraphCore<TNode = SVGElement> {
         .map((commit) => this.withPosition(commit, columns))
         .map((commit) => this.setDefaultColor(commit, columns))
         // Tags need commit style to be computed (with default color).
-        .map((commit) =>
-          commit.setTags(
-            // TODO: move it into setTags
-            this.tags
-              .getNames(commit.hash)
-              .map((name) => new Tag(name, this.template.tag, commit.style)),
-          ),
-        )
+        .map((commit) => commit.setTags(this.tags, this.template.tag))
     );
   }
 

--- a/packages/gitgraph-core/src/gitgraph.ts
+++ b/packages/gitgraph-core/src/gitgraph.ts
@@ -7,7 +7,12 @@ import {
 import { Commit } from "./commit";
 import { createGraphRows } from "./graph-rows";
 import { GraphColumns } from "./graph-columns";
-import { Template, TemplateName, getTemplate } from "./template";
+import {
+  Template,
+  TemplateOptions,
+  TemplateName,
+  getTemplate,
+} from "./template";
 import { Refs } from "./refs";
 import { BranchesPathsCalculator, BranchesPaths } from "./branches-paths";
 import { booleanOptionOr, numberOptionOr } from "./utils";
@@ -62,6 +67,7 @@ class GitgraphCore<TNode = SVGElement> {
 
   public refs = new Refs();
   public tags = new Refs();
+  public tagStyles: { [name: string]: TemplateOptions["tag"] } = {};
   public commits: Array<Commit<TNode>> = [];
   public branches: Map<Branch["name"], Branch<TNode>> = new Map();
   public currentBranch: Branch<TNode>;
@@ -187,7 +193,11 @@ class GitgraphCore<TNode = SVGElement> {
         .map((commit) => this.withPosition(commit, columns))
         .map((commit) => this.setDefaultColor(commit, columns))
         // Tags need commit style to be computed (with default color).
-        .map((commit) => commit.setTags(this.tags, this.template.tag))
+        .map((commit) =>
+          commit.setTags(this.tags, (name) =>
+            Object.assign({}, this.tagStyles[name], this.template.tag),
+          ),
+        )
     );
   }
 

--- a/packages/gitgraph-core/src/gitgraph.ts
+++ b/packages/gitgraph-core/src/gitgraph.ts
@@ -5,6 +5,7 @@ import {
   BranchOptions,
 } from "./branch";
 import { Commit } from "./commit";
+import { Tag } from "./tag";
 import { createGraphRows } from "./graph-rows";
 import { GraphColumns } from "./graph-columns";
 import { Template, TemplateName, getTemplate } from "./template";
@@ -181,11 +182,21 @@ class GitgraphCore<TNode = SVGElement> {
 
     const columns = new GraphColumns<TNode>(commitsWithBranches);
 
-    return commitsWithBranches
-      .map((commit) => commit.setRefs(this.refs))
-      .map((commit) => commit.setTags(this.tags))
-      .map((commit) => this.withPosition(commit, columns))
-      .map((commit) => this.setDefaultColor(commit, columns));
+    return (
+      commitsWithBranches
+        .map((commit) => commit.setRefs(this.refs))
+        .map((commit) => this.withPosition(commit, columns))
+        .map((commit) => this.setDefaultColor(commit, columns))
+        // Tags need commit style to be computed (with default color).
+        .map((commit) =>
+          commit.setTags(
+            // TODO: move it into setTags
+            this.tags
+              .getNames(commit.hash)
+              .map((name) => new Tag(name, this.template.tag, commit.style)),
+          ),
+        )
+    );
   }
 
   /**

--- a/packages/gitgraph-core/src/index.ts
+++ b/packages/gitgraph-core/src/index.ts
@@ -10,6 +10,7 @@ export {
 } from "./user-api/branch-user-api";
 export { Branch } from "./branch";
 export { Commit } from "./commit";
+export { Tag } from "./tag";
 export { Refs } from "./refs";
 export { MergeStyle, TemplateName, templateExtend } from "./template";
 export { Orientation } from "./orientation";

--- a/packages/gitgraph-core/src/tag.ts
+++ b/packages/gitgraph-core/src/tag.ts
@@ -1,0 +1,37 @@
+import { TagStyle, CommitStyle, DEFAULT_FONT } from "./template";
+import { numberOptionOr } from "./utils";
+
+export { Tag };
+
+class Tag {
+  /**
+   * Name
+   */
+  public readonly name: string;
+  /**
+   * Style
+   */
+  public get style(): TagStyle {
+    return {
+      strokeColor: this.tagStyle.strokeColor || this.commitStyle.color,
+      bgColor: this.tagStyle.bgColor || this.commitStyle.color,
+      color: this.tagStyle.color || "white",
+      font: this.tagStyle.font || this.commitStyle.message.font || DEFAULT_FONT,
+      borderRadius: numberOptionOr(this.tagStyle.borderRadius, 10),
+      pointerWidth: numberOptionOr(this.tagStyle.pointerWidth, 12),
+    };
+  }
+
+  private readonly tagStyle: Partial<TagStyle>;
+  private readonly commitStyle: CommitStyle;
+
+  constructor(
+    name: string,
+    tagStyle: Partial<TagStyle>,
+    commitStyle: CommitStyle,
+  ) {
+    this.name = name;
+    this.tagStyle = tagStyle;
+    this.commitStyle = commitStyle;
+  }
+}

--- a/packages/gitgraph-core/src/template.ts
+++ b/packages/gitgraph-core/src/template.ts
@@ -101,6 +101,35 @@ interface BranchLabelStyle {
 
 type BranchLabelStyleOptions = Partial<BranchLabelStyle>;
 
+export interface TagStyle {
+  /**
+   * Tag text color
+   */
+  color: string;
+  /**
+   * Tag stroke color
+   */
+  strokeColor?: string;
+  /**
+   * Tag background color
+   */
+  bgColor?: string;
+  /**
+   * Tag font
+   */
+  font: string;
+  /**
+   * Tag border radius
+   */
+  borderRadius: number;
+  /**
+   * Width of the tag pointer
+   */
+  pointerWidth: number;
+}
+
+type TagStyleOptions = Partial<TagStyle>;
+
 interface CommitDotStyle {
   /**
    * Commit dot color
@@ -205,6 +234,10 @@ interface TemplateOptions {
    * Commit style
    */
   commit?: CommitStyleOptions;
+  /**
+   * Tag style
+   */
+  tag?: TagStyleOptions;
 }
 
 export const DEFAULT_FONT = "normal 12pt Calibri";
@@ -231,6 +264,10 @@ class Template {
    * Commit style
    */
   public commit: CommitStyle;
+  /**
+   * Tag style
+   */
+  public tag: TagStyleOptions;
 
   constructor(options: TemplateOptions) {
     // Options
@@ -299,6 +336,9 @@ class Template {
         font: options.commit.message.font || DEFAULT_FONT,
       },
     };
+
+    // Tag style
+    this.tag = options.tag || {};
   }
 }
 

--- a/packages/gitgraph-core/src/template.ts
+++ b/packages/gitgraph-core/src/template.ts
@@ -338,6 +338,8 @@ class Template {
     };
 
     // Tag style
+    // This one is computed in the Tag instance. It needs Commit style
+    // that is partially computed at runtime (for colors).
     this.tag = options.tag || {};
   }
 }

--- a/packages/gitgraph-core/src/user-api/branch-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/branch-user-api.ts
@@ -22,6 +22,10 @@ interface GitgraphMergeOptions<TNode> {
   fastForward?: boolean;
 }
 
+interface BranchTagOptions {
+  name: string;
+}
+
 class BranchUserApi<TNode> {
   /**
    * Name of the branch.
@@ -129,9 +133,17 @@ class BranchUserApi<TNode> {
   /**
    * Tag the last commit of the branch.
    *
+   * @param options Options of the tag
+   */
+  public tag(options: BranchTagOptions): this;
+  /**
+   * Tag the last commit of the branch.
+   *
    * @param name Name of the tag
    */
-  public tag(name: string): this {
+  public tag(name: string): this;
+  public tag(options?: any): this {
+    const name = typeof options === "string" ? options : options.name;
     this._graph.getUserApi().tag(name, this._branch.name);
     return this;
   }

--- a/packages/gitgraph-core/src/user-api/branch-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/branch-user-api.ts
@@ -24,6 +24,7 @@ interface GitgraphMergeOptions<TNode> {
 
 interface BranchTagOptions {
   name: string;
+  style?: TemplateOptions["tag"];
 }
 
 class BranchUserApi<TNode> {
@@ -143,8 +144,17 @@ class BranchUserApi<TNode> {
    */
   public tag(name: BranchTagOptions["name"]): this;
   public tag(options?: any): this {
-    const name = typeof options === "string" ? options : options.name;
-    this._graph.getUserApi().tag({ name, ref: this._branch.name });
+    let name: BranchTagOptions["name"];
+    let style: BranchTagOptions["style"];
+
+    if (typeof options === "string") {
+      name = options;
+    } else {
+      name = options.name;
+      style = options.style;
+    }
+
+    this._graph.getUserApi().tag({ name, ref: this._branch.name, style });
     return this;
   }
 

--- a/packages/gitgraph-core/src/user-api/branch-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/branch-user-api.ts
@@ -141,7 +141,7 @@ class BranchUserApi<TNode> {
    *
    * @param name Name of the tag
    */
-  public tag(name: string): this;
+  public tag(name: BranchTagOptions["name"]): this;
   public tag(options?: any): this {
     const name = typeof options === "string" ? options : options.name;
     this._graph.getUserApi().tag(name, this._branch.name);

--- a/packages/gitgraph-core/src/user-api/branch-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/branch-user-api.ts
@@ -144,7 +144,7 @@ class BranchUserApi<TNode> {
   public tag(name: BranchTagOptions["name"]): this;
   public tag(options?: any): this {
     const name = typeof options === "string" ? options : options.name;
-    this._graph.getUserApi().tag(name, this._branch.name);
+    this._graph.getUserApi().tag({ name, ref: this._branch.name });
     return this;
   }
 

--- a/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
@@ -27,9 +27,10 @@ interface GitgraphCommitOptions<TNode> extends CommitRenderOptions<TNode> {
   onMouseOut?: (commit: Commit<TNode>) => void;
 }
 
-interface GitgraphTagOptions<TNode> {
+interface GitgraphTagOptions {
   name: string;
-  ref?: Commit<TNode> | Commit["hash"] | Branch["name"];
+  ref?: Commit["hash"] | Branch["name"];
+  style?: TemplateOptions["tag"];
 }
 
 interface GitgraphBranchOptions<TNode> {
@@ -109,7 +110,7 @@ class GitgraphUserApi<TNode> {
    *
    * @param options Options of the tag
    */
-  public tag(options: GitgraphTagOptions<TNode>): this;
+  public tag(options: GitgraphTagOptions): this;
   /**
    * Tag a specific commit.
    *
@@ -117,13 +118,13 @@ class GitgraphUserApi<TNode> {
    * @param ref Commit or branch name or commit hash
    */
   public tag(
-    name: GitgraphTagOptions<TNode>["name"],
-    ref?: GitgraphTagOptions<TNode>["ref"],
+    name: GitgraphTagOptions["name"],
+    ref?: GitgraphTagOptions["ref"],
   ): this;
   public tag(...args: any[]): this {
     // Deal with shorter syntax
-    let name: GitgraphTagOptions<TNode>["name"];
-    let ref: GitgraphTagOptions<TNode>["ref"];
+    let name: GitgraphTagOptions["name"];
+    let ref: GitgraphTagOptions["ref"];
     if (typeof args[0] === "string") {
       name = args[0];
       ref = args[1];
@@ -137,13 +138,6 @@ class GitgraphUserApi<TNode> {
       if (!head) return this;
 
       ref = head;
-    }
-
-    if (typeof ref !== "string") {
-      // `ref` is a `Commit`
-      this._graph.tags.set(name, ref.hash);
-      this._onGraphUpdate();
-      return this;
     }
 
     let commitHash;

--- a/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
@@ -125,12 +125,14 @@ class GitgraphUserApi<TNode> {
     // Deal with shorter syntax
     let name: GitgraphTagOptions["name"];
     let ref: GitgraphTagOptions["ref"];
+    let style: GitgraphTagOptions["style"];
     if (typeof args[0] === "string") {
       name = args[0];
       ref = args[1];
     } else {
       name = args[0].name;
       ref = args[0].ref;
+      style = args[0].style;
     }
 
     if (!ref) {
@@ -156,6 +158,7 @@ class GitgraphUserApi<TNode> {
     }
 
     this._graph.tags.set(name, commitHash);
+    this._graph.tagStyles[name] = style;
     this._onGraphUpdate();
     return this;
   }

--- a/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
@@ -117,13 +117,13 @@ class GitgraphUserApi<TNode> {
    * @param ref Commit or branch name or commit hash
    */
   public tag(
-    name: string,
-    ref?: Commit<TNode> | Commit["hash"] | Branch["name"],
+    name: GitgraphTagOptions<TNode>["name"],
+    ref?: GitgraphTagOptions<TNode>["ref"],
   ): this;
   public tag(...args: any[]): this {
     // Deal with shorter syntax
-    let name;
-    let ref;
+    let name: GitgraphTagOptions<TNode>["name"];
+    let ref: GitgraphTagOptions<TNode>["ref"];
     if (typeof args[0] === "string") {
       name = args[0];
       ref = args[1];

--- a/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
@@ -27,6 +27,11 @@ interface GitgraphCommitOptions<TNode> extends CommitRenderOptions<TNode> {
   onMouseOut?: (commit: Commit<TNode>) => void;
 }
 
+interface GitgraphTagOptions<TNode> {
+  name: string;
+  ref?: Commit<TNode> | Commit["hash"] | Branch["name"];
+}
+
 interface GitgraphBranchOptions<TNode> {
   /**
    * Branch name
@@ -102,13 +107,31 @@ class GitgraphUserApi<TNode> {
   /**
    * Tag a specific commit.
    *
+   * @param options Options of the tag
+   */
+  public tag(options: GitgraphTagOptions<TNode>): this;
+  /**
+   * Tag a specific commit.
+   *
    * @param name Name of the tag
    * @param ref Commit or branch name or commit hash
    */
   public tag(
     name: string,
     ref?: Commit<TNode> | Commit["hash"] | Branch["name"],
-  ): this {
+  ): this;
+  public tag(...args: any[]): this {
+    // Deal with shorter syntax
+    let name;
+    let ref;
+    if (typeof args[0] === "string") {
+      name = args[0];
+      ref = args[1];
+    } else {
+      name = args[0].name;
+      ref = args[0].ref;
+    }
+
     if (!ref) {
       const head = this._graph.refs.getCommit("HEAD");
       if (!head) return this;

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -22,7 +22,7 @@ import {
 import { BranchLabel } from "./BranchLabel";
 import { Tooltip } from "./Tooltip";
 import { Dot } from "./Dot";
-import { TagElement } from "./Tag";
+import { Tag } from "./Tag";
 
 type ReactSvgElement = React.ReactElement<SVGElement>;
 
@@ -356,7 +356,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
           ref={ref}
           transform={`translate(0, ${commit.style.dot.size})`}
         >
-          <TagElement tag={tag} />
+          <Tag tag={tag} />
         </g>
       );
     });
@@ -443,7 +443,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
         moveElement(tag.current, x);
 
         // For some reason, one paddingX is missing in BBox width.
-        const tagWidth = tag.current.getBBox().width + TagElement.paddingX;
+        const tagWidth = tag.current.getBBox().width + Tag.paddingX;
         x += tagWidth + padding;
       });
 

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -22,7 +22,7 @@ import {
 import { BranchLabel } from "./BranchLabel";
 import { Tooltip } from "./Tooltip";
 import { Dot } from "./Dot";
-import { Tag } from "./Tag";
+import { TagElement } from "./Tag";
 
 type ReactSvgElement = React.ReactElement<SVGElement>;
 
@@ -351,8 +351,12 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
       const ref = this.createTagRef(commit);
 
       return (
-        <g key={`${commit.hashAbbrev}-${tag}`} ref={ref}>
-          <Tag name={tag} commit={commit} />
+        <g
+          key={`${commit.hashAbbrev}-${tag.name}`}
+          ref={ref}
+          transform={`translate(0, ${commit.style.dot.size})`}
+        >
+          <TagElement tag={tag} />
         </g>
       );
     });
@@ -439,7 +443,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
         moveElement(tag.current, x);
 
         // For some reason, one paddingX is missing in BBox width.
-        const tagWidth = tag.current.getBBox().width + Tag.paddingX;
+        const tagWidth = tag.current.getBBox().width + TagElement.paddingX;
         x += tagWidth + padding;
       });
 

--- a/packages/gitgraph-react/src/Tag.tsx
+++ b/packages/gitgraph-react/src/Tag.tsx
@@ -27,6 +27,7 @@ export class Tag extends React.Component<Props, State> {
     const { name, commit } = this.props;
 
     const style = {
+      strokeColor: commit.style.color,
       bgColor: commit.style.color,
       borderRadius: 10,
       pointerWidth: 12,
@@ -56,7 +57,7 @@ export class Tag extends React.Component<Props, State> {
 
     return (
       <g transform={`translate(0, ${commit.style.dot.size})`}>
-        <path d={path} fill={style.bgColor} />
+        <path d={path} fill={style.bgColor} stroke={style.strokeColor} />
         <text
           ref={this.$text}
           fill={style.color}

--- a/packages/gitgraph-react/src/Tag.tsx
+++ b/packages/gitgraph-react/src/Tag.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import { Tag } from "@gitgraph/core";
+import { Tag as CoreTag } from "@gitgraph/core";
 
 interface Props {
-  tag: Tag;
+  tag: CoreTag;
 }
 
 interface State {
@@ -10,7 +10,7 @@ interface State {
   textHeight: number;
 }
 
-export class TagElement extends React.Component<Props, State> {
+export class Tag extends React.Component<Props, State> {
   public static readonly paddingX = 10;
   public static readonly paddingY = 5;
   public readonly state = { textWidth: 0, textHeight: 0 };
@@ -27,8 +27,8 @@ export class TagElement extends React.Component<Props, State> {
 
     const offset = tag.style.pointerWidth;
     const radius = tag.style.borderRadius;
-    const boxWidth = offset + this.state.textWidth + 2 * TagElement.paddingX;
-    const boxHeight = this.state.textHeight + 2 * TagElement.paddingY;
+    const boxWidth = offset + this.state.textWidth + 2 * Tag.paddingX;
+    const boxHeight = this.state.textHeight + 2 * Tag.paddingY;
 
     const path = [
       "M 0,0",
@@ -58,7 +58,7 @@ export class TagElement extends React.Component<Props, State> {
           style={{ font: tag.style.font }}
           alignmentBaseline="middle"
           dominantBaseline="middle"
-          x={offset + TagElement.paddingX}
+          x={offset + Tag.paddingX}
           y={0}
         >
           {tag.name}

--- a/packages/gitgraph-react/src/Tag.tsx
+++ b/packages/gitgraph-react/src/Tag.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
-import { Commit } from "@gitgraph/core";
+import { Tag } from "@gitgraph/core";
 
 interface Props {
-  name: string;
-  commit: Commit<React.ReactElement<SVGElement>>;
+  tag: Tag;
 }
 
 interface State {
@@ -11,7 +10,7 @@ interface State {
   textHeight: number;
 }
 
-export class Tag extends React.Component<Props, State> {
+export class TagElement extends React.Component<Props, State> {
   public static readonly paddingX = 10;
   public static readonly paddingY = 5;
   public readonly state = { textWidth: 0, textHeight: 0 };
@@ -24,21 +23,12 @@ export class Tag extends React.Component<Props, State> {
   }
 
   public render() {
-    const { name, commit } = this.props;
+    const { tag } = this.props;
 
-    const style = {
-      strokeColor: commit.style.color,
-      bgColor: commit.style.color,
-      borderRadius: 10,
-      pointerWidth: 12,
-      color: "white",
-      font: commit.style.message.font,
-    };
-
-    const offset = style.pointerWidth;
-    const radius = style.borderRadius;
-    const boxWidth = offset + this.state.textWidth + 2 * Tag.paddingX;
-    const boxHeight = this.state.textHeight + 2 * Tag.paddingY;
+    const offset = tag.style.pointerWidth;
+    const radius = tag.style.borderRadius;
+    const boxWidth = offset + this.state.textWidth + 2 * TagElement.paddingX;
+    const boxHeight = this.state.textHeight + 2 * TagElement.paddingY;
 
     const path = [
       "M 0,0",
@@ -56,18 +46,22 @@ export class Tag extends React.Component<Props, State> {
     ].join(" ");
 
     return (
-      <g transform={`translate(0, ${commit.style.dot.size})`}>
-        <path d={path} fill={style.bgColor} stroke={style.strokeColor} />
+      <g>
+        <path
+          d={path}
+          fill={tag.style.bgColor}
+          stroke={tag.style.strokeColor}
+        />
         <text
           ref={this.$text}
-          fill={style.color}
-          style={{ font: style.font }}
+          fill={tag.style.color}
+          style={{ font: tag.style.font }}
           alignmentBaseline="middle"
           dominantBaseline="middle"
-          x={offset + Tag.paddingX}
+          x={offset + TagElement.paddingX}
           y={0}
         >
-          {name}
+          {tag.name}
         </text>
       </g>
     );

--- a/packages/gitgraph-react/src/stories/1-basic-usage.stories.tsx
+++ b/packages/gitgraph-react/src/stories/1-basic-usage.stories.tsx
@@ -146,6 +146,34 @@ storiesOf("1. Basic usage", module)
       }}
     </Gitgraph>
   ))
+  .add("branch with style", () => (
+    <Gitgraph>
+      {(gitgraph) => {
+        const master = gitgraph.branch({
+          name: "master",
+          style: {
+            label: {
+              bgColor: "#ffce52",
+              color: "black",
+              strokeColor: "#ce9b00",
+              borderRadius: 0,
+              font: "italic 12pt serif",
+            },
+          },
+        });
+
+        master
+          .commit()
+          .commit()
+          .commit();
+
+        gitgraph
+          .branch("feat1")
+          .commit()
+          .commit();
+      }}
+    </Gitgraph>
+  ))
   .add("compact mode", () => (
     <Gitgraph options={{ mode: Mode.Compact }}>
       {(gitgraph) => {

--- a/packages/gitgraph-react/src/stories/1-basic-usage.stories.tsx
+++ b/packages/gitgraph-react/src/stories/1-basic-usage.stories.tsx
@@ -127,8 +127,20 @@ storiesOf("1. Basic usage", module)
         // Tag on gitgraph
         master.commit();
         gitgraph.tag("v2.0");
+        gitgraph.tag({
+          name: "last release",
+          style: {
+            bgColor: "orange",
+            strokeColor: "orange",
+            borderRadius: 0,
+            pointerWidth: 0,
+          },
+        });
 
-        gitgraph.branch("feat1").commit({ tag: "something cool" });
+        gitgraph
+          .branch("feat1")
+          .commit()
+          .tag({ name: "something cool" });
       }}
     </Gitgraph>
   ))

--- a/packages/gitgraph-react/src/stories/1-basic-usage.stories.tsx
+++ b/packages/gitgraph-react/src/stories/1-basic-usage.stories.tsx
@@ -127,20 +127,23 @@ storiesOf("1. Basic usage", module)
         // Tag on gitgraph
         master.commit();
         gitgraph.tag("v2.0");
+
+        // Custom tags
+        const customTagStyle = {
+          bgColor: "orange",
+          strokeColor: "orange",
+          borderRadius: 0,
+          pointerWidth: 0,
+        };
         gitgraph.tag({
           name: "last release",
-          style: {
-            bgColor: "orange",
-            strokeColor: "orange",
-            borderRadius: 0,
-            pointerWidth: 0,
-          },
+          style: customTagStyle,
         });
 
         gitgraph
           .branch("feat1")
           .commit()
-          .tag({ name: "something cool" });
+          .tag({ name: "something cool", style: customTagStyle });
       }}
     </Gitgraph>
   ))

--- a/packages/gitgraph-react/src/stories/5-templates.stories.tsx
+++ b/packages/gitgraph-react/src/stories/5-templates.stories.tsx
@@ -135,4 +135,30 @@ storiesOf("5. Templates", module)
         }}
       </Gitgraph>
     );
+  })
+  .add("with custom tags", () => {
+    const customTags = templateExtend(TemplateName.Metro, {
+      tag: {
+        color: "black",
+        strokeColor: "#ce9b00",
+        bgColor: "#ffce52",
+        font: "italic 12pt serif",
+        borderRadius: 0,
+        pointerWidth: 6,
+      },
+    });
+
+    return (
+      <Gitgraph options={{ template: customTags }}>
+        {(gitgraph) => {
+          gitgraph
+            .commit("one")
+            .tag("v1")
+            .commit("two")
+            .tag("v2")
+            .tag("important")
+            .commit("three");
+        }}
+      </Gitgraph>
+    );
   });


### PR DESCRIPTION
Fixes #151

Tags can be customized at template & tag level (through both gitgraph and branch user APIs):

![image](https://user-images.githubusercontent.com/1094774/54731340-1acd8480-4b64-11e9-82b8-c34d76165806.png)

Default style for blackarrow:

![image](https://user-images.githubusercontent.com/1094774/54731336-1903c100-4b64-11e9-8531-b9ebbf37ea0d.png)
