### PR TITLE
Passing optional commitOptions object to commit

### DIFF
--- a/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.commits.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.commits.test.ts
@@ -40,4 +40,30 @@ describe("Gitgraph.getRenderedData.commits", () => {
       { subject: "Release a new feature" },
     ]);
   });
+
+  it("should accept custom commit options on merge", () => {
+    const core = new GitgraphCore();
+    const gitgraph = core.getUserApi();
+
+    const master = gitgraph.branch("master");
+    master.commit("one");
+
+    const develop = gitgraph.branch("develop");
+    develop.commit("two");
+    master.merge({
+      branch: develop,
+      subject: "Release a new feature",
+      commitOptions: { author: "Fabien Bernard <fabien0102@gmail.com>" },
+    });
+
+    const { commits } = core.getRenderedData();
+
+    expect(commits[2]).toMatchObject({
+      subject: "Release a new feature",
+      author: {
+        name: "Fabien Bernard",
+        email: "fabien0102@gmail.com",
+      },
+    });
+  });
 });

--- a/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.commits.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.commits.test.ts
@@ -52,8 +52,10 @@ describe("Gitgraph.getRenderedData.commits", () => {
     develop.commit("two");
     master.merge({
       branch: develop,
-      subject: "Release a new feature",
-      commitOptions: { author: "Fabien Bernard <fabien0102@gmail.com>" },
+      commitOptions: {
+        subject: "Release a new feature",
+        author: "Fabien Bernard <fabien0102@gmail.com>",
+      },
     });
 
     const { commits } = core.getRenderedData();

--- a/packages/gitgraph-core/src/user-api/branch-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/branch-user-api.ts
@@ -13,10 +13,6 @@ interface GitgraphMergeOptions<TNode> {
    */
   branch: string | BranchUserApi<TNode>;
   /**
-   * Merge commit message subject.
-   */
-  subject?: string;
-  /**
    * If `true`, perform a fast-forward merge (if possible).
    */
   fastForward?: boolean;
@@ -101,11 +97,14 @@ class BranchUserApi<TNode> {
   public merge(...args: any[]): this {
     let options = args[0];
     if (!isBranchMergeOptions<TNode>(options)) {
-      options = { branch: args[0], subject: args[1], fastForward: false };
+      options = {
+        branch: args[0],
+        fastForward: false,
+        commitOptions: { subject: args[1] },
+      };
     }
     const {
       branch,
-      subject,
       fastForward,
       commitOptions,
     } = options as GitgraphMergeOptions<TNode>;
@@ -131,7 +130,12 @@ class BranchUserApi<TNode> {
       this._fastForwardTo(branchLastCommitHash);
     } else {
       this._commitWithParents(
-        { subject: subject || `Merge branch ${branchName}`, ...commitOptions },
+        {
+          ...commitOptions,
+          subject:
+            (commitOptions && commitOptions.subject) ||
+            `Merge branch ${branchName}`,
+        },
         [branchLastCommitHash],
       );
     }

--- a/packages/gitgraph-core/src/user-api/branch-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/branch-user-api.ts
@@ -99,7 +99,7 @@ class BranchUserApi<TNode> {
     if (!isBranchMergeOptions<TNode>(options)) {
       options = { branch: args[0], subject: args[1], fastForward: false };
     }
-    const { branch, subject, fastForward } = options;
+    const { branch, subject, fastForward, ...commitOptions } = options;
 
     const branchName = typeof branch === "string" ? branch : branch.name;
     const branchLastCommitHash = this._graph.refs.getCommit(branchName);
@@ -122,7 +122,7 @@ class BranchUserApi<TNode> {
       this._fastForwardTo(branchLastCommitHash);
     } else {
       this._commitWithParents(
-        { subject: subject || `Merge branch ${branchName}` },
+        { subject: subject || `Merge branch ${branchName}`, ...commitOptions },
         [branchLastCommitHash],
       );
     }

--- a/packages/gitgraph-core/src/user-api/branch-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/branch-user-api.ts
@@ -20,6 +20,10 @@ interface GitgraphMergeOptions<TNode> {
    * If `true`, perform a fast-forward merge (if possible).
    */
   fastForward?: boolean;
+  /**
+   * Commit options.
+   */
+  commitOptions?: GitgraphCommitOptions<TNode>;
 }
 
 interface BranchTagOptions {
@@ -99,7 +103,12 @@ class BranchUserApi<TNode> {
     if (!isBranchMergeOptions<TNode>(options)) {
       options = { branch: args[0], subject: args[1], fastForward: false };
     }
-    const { branch, subject, fastForward, ...commitOptions } = options;
+    const {
+      branch,
+      subject,
+      fastForward,
+      commitOptions,
+    } = options as GitgraphMergeOptions<TNode>;
 
     const branchName = typeof branch === "string" ? branch : branch.name;
     const branchLastCommitHash = this._graph.refs.getCommit(branchName);


### PR DESCRIPTION
Implement #250 adding test and changing `merge()` signature.

@kennyeni I jumped on your proposed change and adapted the signature a bit. I prefer `commitOptions` to be explicit (and typed).

That means instead of doing:

`merge({ branch: develop, dotText: "🛑" });`

You'll need to do:

`merge({ branch: develop, commitOptions: { dotText: "🛑" } });`

It's a bit more verbose, but I like it to distinct the commit options vs. the merge operation options. Also, it will prevent future conflicts.

⚠️ It introduces a breaking change though. This won't work anymore:

`merge({ branch: develop, subject: "Merge branch" })` 

It should be:

`merge({ branch: develop, commitOptions: { subject: "Merge branch" } })`

I also added test & types.