### PR TITLE
Factor expensive computations out of commit iterations

### DIFF
--- a/packages/gitgraph-core/src/gitgraph.ts
+++ b/packages/gitgraph-core/src/gitgraph.ts
@@ -6,6 +6,7 @@ import {
 } from "./branch";
 import { Commit } from "./commit";
 import { createGraphRows } from "./graph-rows";
+import { RegularGraphRows } from "./graph-rows/regular";
 import { BranchesOrder, CompareBranchesOrder } from "./branches-order";
 import {
   Template,
@@ -193,21 +194,26 @@ class GitgraphCore<TNode = SVGElement> {
    * Return commits with data for rendering.
    */
   private computeRenderedCommits(): Array<Commit<TNode>> {
+    const branches = this.getBranches();
     const commitsWithBranches = this.commits.map((commit) =>
-      this.withBranches(commit),
+      this.withBranches(branches, commit),
+    );
+
+    const rows = createGraphRows(this.mode, this.commits);
+    const branchesOrder = new BranchesOrder<TNode>(
+      commitsWithBranches,
+      this.template.colors,
+      this.branchesOrderFunction,
     );
 
     return (
       commitsWithBranches
         .map((commit) => commit.setRefs(this.refs))
-        .map((commit) => this.withPosition(commitsWithBranches, commit))
+        .map((commit) => this.withPosition(rows, branchesOrder, commit))
         // Fallback commit computed color on branch color.
         .map((commit) =>
           commit.withDefaultColor(
-            this.getBranchDefaultColor(
-              commitsWithBranches,
-              commit.branchToDisplay,
-            ),
+            this.getBranchDefaultColor(branchesOrder, commit.branchToDisplay),
           ),
         )
         // Tags need commit style to be computed (with default color).
@@ -246,9 +252,15 @@ class GitgraphCore<TNode = SVGElement> {
     commits: Array<Commit<TNode>>,
     branchesPaths: BranchesPaths<TNode>,
   ): void {
+    const branchesOrder = new BranchesOrder<TNode>(
+      commits,
+      this.template.colors,
+      this.branchesOrderFunction,
+    );
     Array.from(branchesPaths).forEach(([branch]) => {
       branch.computedColor =
-        branch.style.color || this.getBranchDefaultColor(commits, branch.name);
+        branch.style.color ||
+        this.getBranchDefaultColor(branchesOrder, branch.name);
     });
   }
 
@@ -265,11 +277,13 @@ class GitgraphCore<TNode = SVGElement> {
   /**
    * Add `branches` property to commit.
    *
+   * @param branches All branches mapped by commit hash
    * @param commit Commit
    */
-  private withBranches(commit: Commit<TNode>): Commit<TNode> {
-    const branches = this.getBranches();
-
+  private withBranches(
+    branches: Map<Commit["hash"], Set<Branch["name"]>>,
+    commit: Commit<TNode>,
+  ): Commit<TNode> {
     let commitBranches = Array.from(
       (branches.get(commit.hash) || new Set()).values(),
     );
@@ -317,22 +331,18 @@ class GitgraphCore<TNode = SVGElement> {
   /**
    * Add position to given commit.
    *
-   * @param commits List of graph commits
+   * @param rows Graph rows
+   * @param branchesOrder Computed order of branches
    * @param commit Commit to position
    */
   private withPosition(
-    commitsWithBranches: Array<Commit<TNode>>,
+    rows: RegularGraphRows<TNode>,
+    branchesOrder: BranchesOrder<TNode>,
     commit: Commit<TNode>,
   ): Commit<TNode> {
-    const rows = createGraphRows(this.mode, this.commits);
     const row = rows.getRowOf(commit.hash);
     const maxRow = rows.getMaxRow();
 
-    const branchesOrder = new BranchesOrder<TNode>(
-      commitsWithBranches,
-      this.template.colors,
-      this.branchesOrderFunction,
-    );
     const order = branchesOrder.get(commit.branchToDisplay);
 
     switch (this.orientation) {
@@ -369,19 +379,13 @@ class GitgraphCore<TNode = SVGElement> {
   /**
    * Return the default color for given branch.
    *
-   * @param commits List of graph commits
+   * @param branchesOrder Computed order of branches
    * @param branchName Name of the branch
    */
   private getBranchDefaultColor(
-    commits: Array<Commit<TNode>>,
+    branchesOrder: BranchesOrder<TNode>,
     branchName: Branch["name"],
   ): string {
-    const branchesOrder = new BranchesOrder<TNode>(
-      commits,
-      this.template.colors,
-      this.branchesOrderFunction,
-    );
-
     return branchesOrder.getColorOf(branchName);
   }
 

--- a/packages/gitgraph-core/src/graph-rows/regular.ts
+++ b/packages/gitgraph-core/src/graph-rows/regular.ts
@@ -5,6 +5,8 @@ import { Commit } from "../commit";
 export class RegularGraphRows<TNode> {
   protected rows = new Map<Commit["hash"], number>();
 
+  private maxRowCache: number | undefined = undefined;
+
   public constructor(commits: Array<Commit<TNode>>) {
     this.computeRowsFromCommits(commits);
   }
@@ -14,7 +16,10 @@ export class RegularGraphRows<TNode> {
   }
 
   public getMaxRow(): number {
-    return uniq(Array.from(this.rows.values())).length - 1;
+    if (this.maxRowCache === undefined) {
+      this.maxRowCache = uniq(Array.from(this.rows.values())).length - 1;
+    }
+    return this.maxRowCache;
   }
 
   protected computeRowsFromCommits(commits: Array<Commit<TNode>>): void {

--- a/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
@@ -227,8 +227,9 @@ class GitgraphUserApi<TNode> {
     });
 
     // Create branches.
+    const branches = this._getBranches();
     this._graph.commits
-      .map((commit) => this._withBranches(commit))
+      .map((commit) => this._withBranches(branches, commit))
       .reduce((mem, commit) => {
         if (!commit.branches) return mem;
         commit.branches.forEach((branch) => mem.add(branch));
@@ -247,9 +248,10 @@ class GitgraphUserApi<TNode> {
   //
   // These belong to Gitgraph. It is duplicated because of `import()`.
   // `import()` should use regular user API instead.
-  private _withBranches(commit: Commit<TNode>): Commit<TNode> {
-    const branches = this._getBranches();
-
+  private _withBranches(
+    branches: Map<Commit["hash"], Set<Branch["name"]>>,
+    commit: Commit<TNode>,
+  ): Commit<TNode> {
     let commitBranches = Array.from(
       (branches.get(commit.hash) || new Set()).values(),
     );


### PR DESCRIPTION
Currently there are some heavy computations on each commit iteration, for example `withBranches` repeatedly calls `getBranches` of whole graph for each and every commit. This makes performance drop very fast when number of commits is rising. These whole graph computations can be simply factored out and performed just once before iterating through commits.

Average timings on my data (506 commits) before this PR:

import: 561 ms
getRenderedData: 502 ms

After this PR:

import: 100 ms
getRenderedData: 13 ms

@nicoespeon @fabien0102 