### PR TITLE
Drop yup from @gitgraph/core

### DIFF
--- a/packages/gitgraph-core/package.json
+++ b/packages/gitgraph-core/package.json
@@ -42,12 +42,8 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm run test"
   },
-  "dependencies": {
-    "yup": "0.26.3"
-  },
   "devDependencies": {
     "@types/node": "^9.4.6",
-    "@types/yup": "0.24.9",
     "browserify": "^14.5.0",
     "npm-run-all": "^4.1.2",
     "rimraf": "^2.6.2",

--- a/packages/gitgraph-core/src/__tests__/gitgraph.import.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.import.test.ts
@@ -6,22 +6,29 @@ import { Template } from "../template";
 
 describe("Gitgraph.import", () => {
   describe("on invalid input", () => {
+    const INVALID_INPUT_ERROR =
+      "Only `git2json` format is supported for imported data.";
+
     it("should throw if input is not an array", () => {
       const gitgraph = new GitgraphCore().getUserApi();
 
-      expect(() => gitgraph.import({})).toThrow();
+      expect(() => gitgraph.import({})).toThrow(INVALID_INPUT_ERROR);
     });
 
     it("should throw if commits are not objects", () => {
       const gitgraph = new GitgraphCore().getUserApi();
 
-      expect(() => gitgraph.import(["invalid-commit"])).toThrow();
+      expect(() => gitgraph.import(["invalid-commit"])).toThrow(
+        INVALID_INPUT_ERROR,
+      );
     });
 
     it("should throw if commits refs are not array", () => {
       const gitgraph = new GitgraphCore().getUserApi();
 
-      expect(() => gitgraph.import([{ refs: "invalid-refs" }])).toThrow();
+      expect(() => gitgraph.import([{ refs: "invalid-refs" }])).toThrow(
+        INVALID_INPUT_ERROR,
+      );
     });
   });
 

--- a/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
@@ -1,5 +1,3 @@
-import * as yup from "yup";
-
 import { TemplateOptions } from "../template";
 import { Commit, CommitRenderOptions, CommitOptions } from "../commit";
 import {
@@ -172,26 +170,30 @@ class GitgraphUserApi<TNode> {
    * @experimental
    * @param data JSON from `git2json` output
    */
-  public import(data: any) {
-    // Validate `data` format.
-    const schema = yup.array().of(
-      yup.object({
-        refs: yup.array().of(yup.string()),
-        hash: yup.string(),
-        parents: yup.array().of(yup.string()),
-        author: yup.object({
-          name: yup.string(),
-          email: yup.string(),
-        }),
-        subject: yup.string(),
-        body: yup.string(),
-      }),
+  public import(data: unknown) {
+    const invalidData = new Error(
+      "Only `git2json` format is supported for imported data.",
     );
+
+    if (!Array.isArray(data)) {
+      throw invalidData;
+    }
+
+    const areDataValid = data.every((options) => {
+      return (
+        typeof options === "object" &&
+        typeof options.author === "object" &&
+        Array.isArray(options.refs)
+      );
+    });
+
+    if (!areDataValid) {
+      throw invalidData;
+    }
 
     const commitOptionsList: Array<
       CommitOptions<TNode> & { refs: string[] }
-    > = schema
-      .validateSync(data)
+    > = data
       .map((options) => ({
         ...options,
         style: { ...this._graph.template.commit },

--- a/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
@@ -175,6 +175,9 @@ class GitgraphUserApi<TNode> {
       "Only `git2json` format is supported for imported data.",
     );
 
+    // We manually validate input data instead of using a lib like yup.
+    // => this is to keep bundlesize small.
+
     if (!Array.isArray(data)) {
       throw invalidData;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -771,12 +771,6 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.1.0"
 
-"@babel/runtime@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
-  dependencies:
-    regenerator-runtime "^0.12.0"
-
 "@babel/runtime@7.3.1":
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
@@ -1990,10 +1984,6 @@
 "@types/webpack-env@*":
   version "1.13.9"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.13.9.tgz#a67287861c928ebf4159a908d1fb1a2a34d4097a"
-
-"@types/yup@0.24.9":
-  version "0.24.9"
-  resolved "https://registry.yarnpkg.com/@types/yup/-/yup-0.24.9.tgz#da98f4b38eec7ca72146e7042679c8c8628896fa"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -5079,10 +5069,6 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
-
-fn-name@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
 
 focus-lock@^0.6.0:
   version "0.6.2"
@@ -8531,10 +8517,6 @@ prop-types@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-property-expr@^1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.5.1.tgz#22e8706894a0c8e28d58735804f6ba3a3673314f"
-
 property-information@^5.0.0, property-information@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.0.1.tgz#c3b09f4f5750b1634c0b24205adbf78f18bdf94f"
@@ -10135,10 +10117,6 @@ symbol.prototype.description@^1.0.0:
   dependencies:
     has-symbols "^1.0.0"
 
-synchronous-promise@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.5.tgz#4e0fc8dd3f0062720dcc4cefbd9eae62b40637d8"
-
 syntax-error@^1.1.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/syntax-error/-/syntax-error-1.4.0.tgz#2d9d4ff5c064acb711594a3e3b95054ad51d907c"
@@ -10336,10 +10314,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
-
-toposort@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
 
 tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
   version "2.4.3"
@@ -11120,14 +11094,3 @@ yargs@^12.0.1:
 yn@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
-
-yup@0.26.3:
-  version "0.26.3"
-  resolved "https://registry.yarnpkg.com/yup/-/yup-0.26.3.tgz#66f2d4a474068e63f44a575d8341a24bb82de5bc"
-  dependencies:
-    "@babel/runtime" "7.0.0"
-    fn-name "~2.0.1"
-    lodash "^4.17.10"
-    property-expr "^1.5.0"
-    synchronous-promise "^2.0.5"
-    toposort "^2.0.2"


### PR DESCRIPTION
Related to #202.

It turns out yup is adding a lot to bundlesize. It depends on lodash, so it adds a lot of code:

![image](https://user-images.githubusercontent.com/1094774/55677943-4fa93d80-58bf-11e9-94d0-2114e910181d.png)

Regarding that we only used a subset of it in one method (`import`), I decided it doesn't worth it and we can manually test the input format of data. Plus, in practice, it's very likely people will use `git2json` as documented, so there should be no invalid data as an input.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/1094774/55677955-83846300-58bf-11e9-92d9-7d55ecc5152a.png) | ![image](https://user-images.githubusercontent.com/1094774/55677958-897a4400-58bf-11e9-85de-dc22bdeaec2f.png) |

Look at that, we're back at the size of `gitgraph.js` package for the core 🎉 

