### PR TITLE
Branching from another branch

### DIFF
--- a/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.branches.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.branches.test.ts
@@ -80,6 +80,37 @@ describe("Gitgraph.getRenderedData.branches", () => {
     ]);
   });
 
+  it("should create branch from another one", () => {
+    const core = new GitgraphCore();
+    const gitgraph = core.getUserApi();
+
+    const master = gitgraph.branch("master");
+    master.commit("one");
+
+    const feat1 = gitgraph.branch("feat1");
+    feat1.commit("two");
+
+    const feat2 = gitgraph.branch({ name: "feat2", from: master });
+    feat2.commit("three");
+
+    const { commits } = core.getRenderedData();
+
+    expect(commits).toMatchObject([
+      {
+        subject: "one",
+        branches: ["master", "feat1", "feat2"],
+      },
+      {
+        subject: "two",
+        branches: ["feat1"],
+      },
+      {
+        subject: "three",
+        branches: ["feat2"],
+      },
+    ]);
+  });
+
   it("should calculate branch to display", () => {
     const core = new GitgraphCore();
     const gitgraph = core.getUserApi();

--- a/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.branches.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.branches.test.ts
@@ -93,20 +93,27 @@ describe("Gitgraph.getRenderedData.branches", () => {
     const feat2 = gitgraph.branch({ name: "feat2", from: master });
     feat2.commit("three");
 
+    const feat1Part1 = feat1.branch("feat1/part1");
+    feat1Part1.commit("four");
+
     const { commits } = core.getRenderedData();
 
     expect(commits).toMatchObject([
       {
         subject: "one",
-        branches: ["master", "feat1", "feat2"],
+        branches: ["master", "feat1", "feat2", "feat1/part1"],
       },
       {
         subject: "two",
-        branches: ["feat1"],
+        branches: ["feat1", "feat1/part1"],
       },
       {
         subject: "three",
         branches: ["feat2"],
+      },
+      {
+        subject: "four",
+        branches: ["feat1/part1"],
       },
     ]);
   });

--- a/packages/gitgraph-core/src/gitgraph.ts
+++ b/packages/gitgraph-core/src/gitgraph.ts
@@ -1,9 +1,4 @@
-import {
-  Branch,
-  DELETED_BRANCH_NAME,
-  createDeletedBranch,
-  BranchOptions,
-} from "./branch";
+import { Branch, DELETED_BRANCH_NAME, createDeletedBranch } from "./branch";
 import { Commit } from "./commit";
 import { createGraphRows, GraphRows } from "./graph-rows";
 import { BranchesOrder, CompareBranchesOrder } from "./branches-order";

--- a/packages/gitgraph-core/src/gitgraph.ts
+++ b/packages/gitgraph-core/src/gitgraph.ts
@@ -165,21 +165,29 @@ class GitgraphCore<TNode = SVGElement> {
    */
   public createBranch(name: string): Branch<TNode>;
   public createBranch(args: any): Branch<TNode> {
-    const parentCommitHash = this.refs.getCommit("HEAD");
-    let options: BranchOptions<TNode> = {
+    const defaultParentBranchName = "HEAD";
+
+    let options = {
       gitgraph: this,
       name: "",
-      parentCommitHash,
+      parentCommitHash: this.refs.getCommit(defaultParentBranchName),
       style: this.template.branch,
       onGraphUpdate: () => this.next(),
     };
+
     if (typeof args === "string") {
       options.name = args;
+      options.parentCommitHash = this.refs.getCommit(defaultParentBranchName);
     } else {
+      const parentBranchName = args.from
+        ? args.from.name
+        : defaultParentBranchName;
+
       args.style = args.style || {};
       options = {
         ...options,
         ...args,
+        parentCommitHash: this.refs.getCommit(parentBranchName),
         style: {
           ...options.style,
           ...args.style,
@@ -190,6 +198,7 @@ class GitgraphCore<TNode = SVGElement> {
         },
       };
     }
+
     const branch = new Branch<TNode>(options);
     this.branches.set(branch.name, branch);
 

--- a/packages/gitgraph-core/src/user-api/branch-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/branch-user-api.ts
@@ -1,9 +1,12 @@
 import { GitgraphCore, Mode } from "../gitgraph";
-import { GitgraphCommitOptions } from "./gitgraph-user-api";
+import {
+  GitgraphCommitOptions,
+  GitgraphBranchOptions,
+} from "./gitgraph-user-api";
 import { TemplateOptions, CommitStyle } from "../template";
 import { Commit } from "../commit";
 import { Branch } from "../branch";
-import { withoutUndefinedKeys } from "../utils";
+import { withoutUndefinedKeys, Omit } from "../utils";
 
 export { BranchUserApi, GitgraphMergeOptions };
 
@@ -49,6 +52,29 @@ class BranchUserApi<TNode> {
     this.name = branch.name;
     this._graph = graph;
     this._onGraphUpdate = onGraphUpdate;
+  }
+
+  /**
+   * Create a new branch (as `git branch`).
+   *
+   * @param options Options of the branch
+   */
+  public branch(
+    options: Omit<GitgraphBranchOptions<TNode>, "from">,
+  ): BranchUserApi<TNode>;
+  /**
+   * Create a new branch (as `git branch`).
+   *
+   * @param name Name of the created branch
+   */
+  public branch(name: string): BranchUserApi<TNode>;
+  public branch(args: any): BranchUserApi<TNode> {
+    const options: GitgraphBranchOptions<TNode> =
+      typeof args === "string" ? { name: args } : args;
+
+    options.from = this;
+
+    return this._graph.createBranch(options).getUserApi();
   }
 
   /**

--- a/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
@@ -37,6 +37,10 @@ interface GitgraphBranchOptions<TNode> {
    */
   name: string;
   /**
+   * Origin branch
+   */
+  from?: BranchUserApi<TNode>;
+  /**
    * Default options for commits
    */
   commitDefaultOptions?: BranchCommitDefaultOptions<TNode>;

--- a/packages/stories/src/gitgraph-js/1-basic-usage.stories.tsx
+++ b/packages/stories/src/gitgraph-js/1-basic-usage.stories.tsx
@@ -266,6 +266,9 @@ storiesOf("gitgraph-js/1. Basic usage", module)
           from: master,
         });
         feat2.commit();
+
+        const feat1Part2 = feat1.branch("feat1/part2");
+        feat1Part2.commit().commit();
       }}
     </GraphContainer>
   ))

--- a/packages/stories/src/gitgraph-js/1-basic-usage.stories.tsx
+++ b/packages/stories/src/gitgraph-js/1-basic-usage.stories.tsx
@@ -248,6 +248,27 @@ storiesOf("gitgraph-js/1. Basic usage", module)
       }}
     </GraphContainer>
   ))
+  .add("branching from a past reference", () => (
+    <GraphContainer>
+      {(graphContainer) => {
+        const gitgraph = createGitgraph(graphContainer, {
+          generateCommitHash: createFixedHashGenerator(),
+        });
+
+        const master = gitgraph.branch("master");
+        master.commit();
+
+        const feat1 = gitgraph.branch("feat1");
+        feat1.commit().commit();
+
+        const feat2 = gitgraph.branch({
+          name: "feat2",
+          from: master,
+        });
+        feat2.commit();
+      }}
+    </GraphContainer>
+  ))
   .add("compact mode", () => (
     <GraphContainer>
       {(graphContainer) => {

--- a/packages/stories/src/gitgraph-react/1-basic-usage.stories.tsx
+++ b/packages/stories/src/gitgraph-react/1-basic-usage.stories.tsx
@@ -208,6 +208,23 @@ storiesOf("gitgraph-react/1. Basic usage", module)
       }}
     </Gitgraph>
   ))
+  .add("branching from a past reference", () => (
+    <Gitgraph options={{ generateCommitHash: createFixedHashGenerator() }}>
+      {(gitgraph) => {
+        const master = gitgraph.branch("master");
+        master.commit();
+
+        const feat1 = gitgraph.branch("feat1");
+        feat1.commit().commit();
+
+        const feat2 = gitgraph.branch({
+          name: "feat2",
+          from: master,
+        });
+        feat2.commit();
+      }}
+    </Gitgraph>
+  ))
   .add("compact mode", () => (
     <Gitgraph
       options={{

--- a/packages/stories/src/gitgraph-react/1-basic-usage.stories.tsx
+++ b/packages/stories/src/gitgraph-react/1-basic-usage.stories.tsx
@@ -222,6 +222,9 @@ storiesOf("gitgraph-react/1. Basic usage", module)
           from: master,
         });
         feat2.commit();
+
+        const feat1Part2 = feat1.branch("feat1/part2");
+        feat1Part2.commit().commit();
       }}
     </Gitgraph>
   ))


### PR DESCRIPTION
Fixes #271.

Now we can create a branch from another one. 

The first way is to pass the parent branch reference in the `from` attribute:

```js
const master = gitgraph.branch("master").commit();

// …

const feature = gitgraph.branch({
  name: "feature",
  from: master 
});
```

But I also added the `branch()` method to BranchUserApi, so it's possible to create a branch from another one, like so:

```js
const master = gitgraph.branch("master").commit();

// …

const feature = master.branch("feature");
```