### PR TITLE
feat: Create branch from hash

### DIFF
--- a/packages/gitgraph-core/src/__tests__/branch.test.ts
+++ b/packages/gitgraph-core/src/__tests__/branch.test.ts
@@ -28,19 +28,19 @@ describe("Branch", () => {
     it("should be able to branch from hash", () => {
       const core = new GitgraphCore();
       const gitgraph = core.getUserApi();
+
       const master = gitgraph.branch("master");
-      master.commit("master 1");
-      master.commit("master 2");
-      let { commits } = core.getRenderedData();
-      const pastCommit = commits.find((c) => c.subject === "master 1");
+      const commitHash = "abc1234";
+      master.commit({ subject: "one", hash: commitHash });
+      master.commit("two");
       const fromHash = gitgraph.branch({
         name: "fromHash",
-        from: pastCommit.hash,
+        from: commitHash,
       });
-      fromHash.commit("fromHash 1");
-      commits = core.getRenderedData().commits;
-      const newCommit = commits.find((c) => c.subject === "fromHash 1");
-      expect(newCommit.parents.length).toBe(1);
+      fromHash.commit("three");
+
+      const { commits } = core.getRenderedData();
+      expect(commits[commits.length - 1].parents.length).toBe(1);
     });
 
     it("should create a merge commit into master", () => {

--- a/packages/gitgraph-core/src/__tests__/branch.test.ts
+++ b/packages/gitgraph-core/src/__tests__/branch.test.ts
@@ -25,6 +25,24 @@ describe("Branch", () => {
       log = commits;
     });
 
+    it("should be able to branch from hash", () => {
+      const core = new GitgraphCore();
+      const gitgraph = core.getUserApi();
+      const master = gitgraph.branch("master");
+      master.commit("master 1");
+      master.commit("master 2");
+      let { commits } = core.getRenderedData();
+      const pastCommit = commits.find((c) => c.subject === "master 1");
+      const fromHash = gitgraph.branch({
+        name: "fromHash",
+        from: pastCommit.hash,
+      });
+      fromHash.commit("fromHash 1");
+      commits = core.getRenderedData().commits;
+      const newCommit = commits.find((c) => c.subject === "fromHash 1");
+      expect(newCommit.parents.length).toBe(1);
+    });
+
     it("should create a merge commit into master", () => {
       const mergeCommit = log.find((c) => c.subject === "Merge branch develop");
       expect(mergeCommit).toBeDefined();

--- a/packages/gitgraph-core/src/gitgraph.ts
+++ b/packages/gitgraph-core/src/gitgraph.ts
@@ -178,16 +178,14 @@ class GitgraphCore<TNode = SVGElement> {
       const parentBranchName = args.from
         ? args.from.name
         : defaultParentBranchName;
-
+      const parentCommitHash =
+        this.refs.getCommit(parentBranchName) ||
+        (this.refs.hasCommit(args.from) ? args.from : undefined);
       args.style = args.style || {};
       options = {
         ...options,
         ...args,
-        parentCommitHash:
-          this.refs.getCommit(parentBranchName) ||
-          (this.refs.hasCommit(parentBranchName)
-            ? parentBranchName
-            : undefined),
+        parentCommitHash,
         style: {
           ...options.style,
           ...args.style,

--- a/packages/gitgraph-core/src/gitgraph.ts
+++ b/packages/gitgraph-core/src/gitgraph.ts
@@ -183,7 +183,11 @@ class GitgraphCore<TNode = SVGElement> {
       options = {
         ...options,
         ...args,
-        parentCommitHash: this.refs.getCommit(parentBranchName),
+        parentCommitHash:
+          this.refs.getCommit(parentBranchName) ||
+          (this.refs.hasCommit(parentBranchName)
+            ? parentBranchName
+            : undefined),
         style: {
           ...options.style,
           ...args.style,

--- a/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
@@ -44,9 +44,9 @@ interface GitgraphBranchOptions<TNode> extends BranchRenderOptions<TNode> {
    */
   name: string;
   /**
-   * Origin branch
+   * Origin branch or commit hash
    */
-  from?: BranchUserApi<TNode>;
+  from?: BranchUserApi<TNode> | string;
   /**
    * Default options for commits
    */

--- a/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
@@ -46,7 +46,7 @@ interface GitgraphBranchOptions<TNode> extends BranchRenderOptions<TNode> {
   /**
    * Origin branch or commit hash
    */
-  from?: BranchUserApi<TNode> | string;
+  from?: BranchUserApi<TNode> | Commit["hash"];
   /**
    * Default options for commits
    */

--- a/packages/stories/src/gitgraph-js/1-basic-usage.stories.tsx
+++ b/packages/stories/src/gitgraph-js/1-basic-usage.stories.tsx
@@ -2,7 +2,11 @@ import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { createGitgraph, Mode, Branch } from "@gitgraph/js";
 
-import { createFixedHashGenerator, GraphContainer } from "../helpers";
+import {
+  createFixedHashGenerator,
+  GraphContainer,
+  hashPrefix,
+} from "../helpers";
 
 storiesOf("gitgraph-js/1. Basic usage", module)
   .add("default", () => (
@@ -245,6 +249,24 @@ storiesOf("gitgraph-js/1. Basic usage", module)
           .branch("feat1")
           .commit()
           .commit();
+      }}
+    </GraphContainer>
+  ))
+  .add("branching from a past commit hash", () => (
+    <GraphContainer>
+      {(graphContainer) => {
+        const gitgraph = createGitgraph(graphContainer, {
+          generateCommitHash: createFixedHashGenerator(),
+        });
+        const master = gitgraph.branch("master");
+        master.commit();
+        const feat1 = gitgraph.branch("feat1");
+        feat1.commit().commit();
+        const feat2 = gitgraph.branch({
+          name: "feat2",
+          from: `${hashPrefix}1`,
+        });
+        feat2.commit();
       }}
     </GraphContainer>
   ))

--- a/packages/stories/src/gitgraph-react/1-basic-usage.stories.tsx
+++ b/packages/stories/src/gitgraph-react/1-basic-usage.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { Gitgraph, Mode, Branch } from "@gitgraph/react";
 
-import { createFixedHashGenerator } from "../helpers";
+import { createFixedHashGenerator, hashPrefix } from "../helpers";
 
 storiesOf("gitgraph-react/1. Basic usage", module)
   .add("default", () => (
@@ -205,6 +205,21 @@ storiesOf("gitgraph-react/1. Basic usage", module)
           .branch("feat1")
           .commit()
           .commit();
+      }}
+    </Gitgraph>
+  ))
+  .add("branching from a past commit hash", () => (
+    <Gitgraph options={{ generateCommitHash: createFixedHashGenerator() }}>
+      {(gitgraph) => {
+        const master = gitgraph.branch("master");
+        master.commit();
+        const feat1 = gitgraph.branch("feat1");
+        feat1.commit().commit();
+        const feat2 = gitgraph.branch({
+          name: "feat2",
+          from: `${hashPrefix}1`,
+        });
+        feat2.commit();
       }}
     </Gitgraph>
   ))

--- a/packages/stories/src/helpers.tsx
+++ b/packages/stories/src/helpers.tsx
@@ -11,9 +11,10 @@ export {
   createForeignObject,
 };
 
+export const hashPrefix = "h45h";
 function createFixedHashGenerator() {
   let hashIndex = 0;
-  return () => `h45h${hashIndex++}`;
+  return () => `${hashPrefix}${hashIndex++}`;
 }
 
 /**


### PR DESCRIPTION
- Accept hash as `from.name` when creating a branch


I have a use case where I want to go back in the commit and branch from that particular hash, is there any other supported why?