### PR TITLE
Pass graph as a prop to react component

### DIFF
--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -51,6 +51,7 @@ export {
 
 interface GitgraphProps {
   options?: GitgraphOptions;
+  graph?: GitgraphCore<ReactSvgElement>;
   children: (gitgraph: GitgraphUserApi<ReactSvgElement>) => void;
 }
 
@@ -94,7 +95,8 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
       shouldRecomputeOffsets: true,
       currentCommitOver: null,
     };
-    this.gitgraph = new GitgraphCore<ReactSvgElement>(props.options);
+    this.gitgraph =
+      props.graph || new GitgraphCore<ReactSvgElement>(props.options);
     this.gitgraph.subscribe((data) => {
       const { commits, branchesPaths, commitMessagesX } = data;
       this.setState({


### PR DESCRIPTION
Good evening! 

Thanks for creating such a nice library! 

I have a use case where I have to keep updating the graph and update it on demand. This implies that I could create an instance of `GitgraphCore` and render it later. However, the React component does not allow such usage. That means I have to populate graph for the scratch every time I mount the component. 

It would be really nice to have a workflow where React component behaves only as a pure renderer and data to be rendered could be controlled from outside.

Kind regards,
Elchin.