### PR TITLE
Fix commit display without message

### DIFF
--- a/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.style.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.style.test.ts
@@ -1,7 +1,12 @@
 import { GitgraphCore } from "../gitgraph";
 import { Mode } from "../mode";
 import { BranchOptions } from "../branch";
-import { metroTemplate, TemplateName, blackArrowTemplate } from "../template";
+import {
+  metroTemplate,
+  TemplateName,
+  blackArrowTemplate,
+  templateExtend,
+} from "../template";
 import { Orientation } from "../orientation";
 
 describe("Gitgraph.getRenderedData.style", () => {
@@ -187,6 +192,26 @@ describe("Gitgraph.getRenderedData.style", () => {
     const core = new GitgraphCore({
       orientation: Orientation.HorizontalReverse,
     });
+    const gitgraph = core.getUserApi();
+
+    gitgraph.commit();
+
+    const { commits } = core.getRenderedData();
+    const [commit] = commits;
+
+    expect(commit.style.message.display).toBe(false);
+  });
+
+  it("should hide message if so specified in template", () => {
+    const template = templateExtend(TemplateName.Metro, {
+      commit: {
+        message: {
+          display: false,
+        },
+      },
+    });
+
+    const core = new GitgraphCore({ template });
     const gitgraph = core.getUserApi();
 
     gitgraph.commit();

--- a/packages/gitgraph-core/src/user-api/branch-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/branch-user-api.ts
@@ -280,8 +280,10 @@ class BranchUserApi<TNode> {
         ...withoutUndefinedKeys(
           this._branch.commitDefaultOptions.style!.message,
         ),
-        display: this._graph.shouldDisplayCommitMessage,
         ...style.message,
+        ...withoutUndefinedKeys({
+          display: this._graph.shouldDisplayCommitMessage && undefined,
+        }),
       },
       dot: {
         ...withoutUndefinedKeys(this._graph.template.commit.dot),

--- a/packages/stories/src/gitgraph-react/5-templates.stories.tsx
+++ b/packages/stories/src/gitgraph-react/5-templates.stories.tsx
@@ -67,6 +67,31 @@ storiesOf("gitgraph-react/5. Templates", module)
       }}
     </Gitgraph>
   ))
+  .add("without commit message", () => {
+    const withoutMessage= templateExtend(TemplateName.Metro, {
+      commit: {
+        message: {
+          display: false,
+        },
+      },
+    });
+
+    return (
+      <Gitgraph
+        options={{
+          template: withoutMessage,
+          generateCommitHash: createFixedHashGenerator(),
+        }}
+      >
+        {(gitgraph) => {
+          gitgraph
+            .commit("one")
+            .commit("two")
+            .commit("three");
+        }}
+      </Gitgraph>
+    );
+  })
   .add("without commit hash", () => {
     const withoutHash = templateExtend(TemplateName.Metro, {
       commit: {

--- a/packages/stories/src/gitgraph-react/5-templates.stories.tsx
+++ b/packages/stories/src/gitgraph-react/5-templates.stories.tsx
@@ -67,31 +67,6 @@ storiesOf("gitgraph-react/5. Templates", module)
       }}
     </Gitgraph>
   ))
-  .add("without commit message", () => {
-    const withoutMessage= templateExtend(TemplateName.Metro, {
-      commit: {
-        message: {
-          display: false,
-        },
-      },
-    });
-
-    return (
-      <Gitgraph
-        options={{
-          template: withoutMessage,
-          generateCommitHash: createFixedHashGenerator(),
-        }}
-      >
-        {(gitgraph) => {
-          gitgraph
-            .commit("one")
-            .commit("two")
-            .commit("three");
-        }}
-      </Gitgraph>
-    );
-  })
   .add("without commit hash", () => {
     const withoutHash = templateExtend(TemplateName.Metro, {
       commit: {


### PR DESCRIPTION
This PR is created to show an existing bug in commit rending in `gitgraph/core`. It is most likely introduced by commit 5f022ef4b4458b9b851ff74cbed42588367801c0. 

@nicoespeon @fabien0102 Please take a look. I could try to fix it myself if you want. I just thought that you can fix it much faster. 

Cheers,
Elchin.