### PR TITLE
Allow padding to be changed in template options (gitgraph-js)

### DIFF
--- a/packages/gitgraph-core/src/template.ts
+++ b/packages/gitgraph-core/src/template.ts
@@ -95,6 +95,14 @@ interface BranchLabelStyle {
    * Branch label border radius
    */
   borderRadius: number;
+  /**
+   * Branch label padding on x axis
+   */
+  paddingX: number;
+  /**
+   * Branch label padding on y axis
+   */
+  paddingY: number;
 }
 
 type BranchLabelStyleOptions = Partial<BranchLabelStyle>;

--- a/packages/gitgraph-js/src/branch-label.ts
+++ b/packages/gitgraph-js/src/branch-label.ts
@@ -7,6 +7,8 @@ const PADDING_X = 10;
 const PADDING_Y = 5;
 
 function createBranchLabel(branch: Branch, commit: Commit): SVGElement {
+  const paddingX = branch.style.label.paddingX || PADDING_X;
+  const paddingY = branch.style.label.paddingY || PADDING_Y;
   const rect = createRect({
     width: 0,
     height: 0,
@@ -17,7 +19,7 @@ function createBranchLabel(branch: Branch, commit: Commit): SVGElement {
   const text = createText({
     content: branch.name,
     translate: {
-      x: PADDING_X,
+      x: paddingX,
       y: 0,
     },
     font: branch.style.label.font,
@@ -29,8 +31,8 @@ function createBranchLabel(branch: Branch, commit: Commit): SVGElement {
   const observer = new MutationObserver(() => {
     const { height, width } = text.getBBox();
 
-    const boxWidth = width + 2 * PADDING_X;
-    const boxHeight = height + 2 * PADDING_Y;
+    const boxWidth = width + 2 * paddingX;
+    const boxHeight = height + 2 * paddingY;
 
     // Ideally, it would be great to refactor these behavior into SVG elements.
     rect.setAttribute("width", boxWidth.toString());

--- a/packages/gitgraph-js/src/branch-label.ts
+++ b/packages/gitgraph-js/src/branch-label.ts
@@ -7,8 +7,14 @@ const PADDING_X = 10;
 const PADDING_Y = 5;
 
 function createBranchLabel(branch: Branch, commit: Commit): SVGElement {
-  const paddingX = branch.style.label.paddingX || PADDING_X;
-  const paddingY = branch.style.label.paddingY || PADDING_Y;
+  const paddingX =
+    branch.style.label.paddingX !== undefined
+      ? branch.style.label.paddingX
+      : PADDING_X;
+  const paddingY =
+    branch.style.label.paddingY !== undefined
+      ? branch.style.label.paddingY
+      : PADDING_Y;
   const rect = createRect({
     width: 0,
     height: 0,

--- a/packages/gitgraph-react/src/BranchLabel.tsx
+++ b/packages/gitgraph-react/src/BranchLabel.tsx
@@ -26,8 +26,14 @@ export class BranchLabel extends React.Component<Props, State> {
   public render() {
     const { branch, commit } = this.props;
 
-    const paddingX = branch.style.label.paddingX || BranchLabel.paddingX;
-    const paddingY = branch.style.label.paddingY || BranchLabel.paddingY;
+    const paddingX =
+      branch.style.label.paddingX !== undefined
+        ? branch.style.label.paddingX
+        : BranchLabel.paddingX;
+    const paddingY =
+      branch.style.label.paddingY !== undefined
+        ? branch.style.label.paddingY
+        : BranchLabel.paddingY;
     const boxWidth = this.state.textWidth + 2 * paddingX;
     const boxHeight = this.state.textHeight + 2 * paddingY;
 

--- a/packages/gitgraph-react/src/BranchLabel.tsx
+++ b/packages/gitgraph-react/src/BranchLabel.tsx
@@ -26,8 +26,10 @@ export class BranchLabel extends React.Component<Props, State> {
   public render() {
     const { branch, commit } = this.props;
 
-    const boxWidth = this.state.textWidth + 2 * BranchLabel.paddingX;
-    const boxHeight = this.state.textHeight + 2 * BranchLabel.paddingY;
+    const paddingX = branch.style.label.paddingX || BranchLabel.paddingX;
+    const paddingY = branch.style.label.paddingY || BranchLabel.paddingY;
+    const boxWidth = this.state.textWidth + 2 * paddingX;
+    const boxHeight = this.state.textHeight + 2 * paddingY;
 
     return (
       <g>
@@ -44,7 +46,7 @@ export class BranchLabel extends React.Component<Props, State> {
           style={{ font: branch.style.label.font }}
           alignmentBaseline="middle"
           dominantBaseline="middle"
-          x={BranchLabel.paddingX}
+          x={paddingX}
           y={boxHeight / 2}
         >
           {branch.name}

--- a/packages/stories/src/gitgraph-js/5-templates.stories.tsx
+++ b/packages/stories/src/gitgraph-js/5-templates.stories.tsx
@@ -147,6 +147,8 @@ storiesOf("gitgraph-js/5. Templates", module)
               strokeColor: "#ce9b00",
               borderRadius: 0,
               font: "italic 12pt serif",
+              paddingX: 5,
+              paddingY: 2,
             },
           },
         });

--- a/packages/stories/src/gitgraph-react/5-templates.stories.tsx
+++ b/packages/stories/src/gitgraph-react/5-templates.stories.tsx
@@ -151,6 +151,8 @@ storiesOf("gitgraph-react/5. Templates", module)
           strokeColor: "#ce9b00",
           borderRadius: 0,
           font: "italic 12pt serif",
+          paddingX: 15,
+          paddingY: 0,
         },
       },
     });


### PR DESCRIPTION
No styling option should be hardcoded. 

When the user decides the spacing of commits should be smaller then the labels are height, the labels and tags overlap each other and you can't decrease the size of the labels (at least not smaller than 22px).

I'm almost sure the same issue exists in the tags. But for now tell me what you think about before I invest more time in it.