### PR TITLE
Fix ineffective merge when fastForward is set to false

### DIFF
--- a/packages/gitgraph-core/src/user-api/branch-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/branch-user-api.ts
@@ -140,14 +140,14 @@ class BranchUserApi<TNode> {
     }
 
     let canFastForward = false;
-    const lastCommitHash = this._graph.refs.getCommit(this._branch.name);
-    if (lastCommitHash) {
-      canFastForward = this._areCommitsConnected(
-        lastCommitHash,
-        branchLastCommitHash,
-      );
-    } else {
-      canFastForward = false;
+    if (fastForward) {
+      const lastCommitHash = this._graph.refs.getCommit(this._branch.name);
+      if (lastCommitHash) {
+        canFastForward = this._areCommitsConnected(
+          lastCommitHash,
+          branchLastCommitHash,
+        );
+      }
     }
 
     if (fastForward && canFastForward) {


### PR DESCRIPTION
Hello! Thanks a lot for this beautiful library!

Recently I stumbled on a problem with very slow performance during `merge`  without `fastForward` operation of `BranchUserApi` class. I have found out that despite `fastForward` argument being set to `false` an expensive `_areCommitsConnected` was still run. I've changed logic a bit to address the issue.