### PR TITLE
Fixing graph when the same branch is merged multiple times in a row

### DIFF
--- a/packages/gitgraph-core/src/branches-paths.ts
+++ b/packages/gitgraph-core/src/branches-paths.ts
@@ -181,14 +181,16 @@ class BranchesPathsCalculator<TNode> {
         (mem, point, i) => {
           if (point.mergeCommit) {
             mem[mem.length - 1].push(pick(point, ["x", "y"]));
-            var j = i - 1;
-            var previousPoint = points[j];
-            // finding the last of the previous points which is not a merge
+            let j = i - 1;
+            let previousPoint = points[j];
+
+            // Find the last point which is not a merge
             while (j >= 0 && previousPoint.mergeCommit) {
               j--;
               previousPoint = points[j];
             }
-            // starting a new array with this point
+
+            // Start a new array with this point
             if (j >= 0) {
               mem.push([previousPoint]);
             }

--- a/packages/gitgraph-core/src/branches-paths.ts
+++ b/packages/gitgraph-core/src/branches-paths.ts
@@ -181,7 +181,17 @@ class BranchesPathsCalculator<TNode> {
         (mem, point, i) => {
           if (point.mergeCommit) {
             mem[mem.length - 1].push(pick(point, ["x", "y"]));
-            if (points[i - 1]) mem.push([points[i - 1]]);
+            var j = i - 1;
+            var previousPoint = points[j];
+            // finding the last of the previous points which is not a merge
+            while (j >= 0 && previousPoint.mergeCommit) {
+              j--;
+              previousPoint = points[j];
+            }
+            // starting a new array with this point
+            if (j >= 0) {
+              mem.push([previousPoint]);
+            }
           } else {
             mem[mem.length - 1].push(point);
           }

--- a/packages/stories/src/gitgraph-js/1-basic-usage.stories.tsx
+++ b/packages/stories/src/gitgraph-js/1-basic-usage.stories.tsx
@@ -123,9 +123,11 @@ storiesOf("gitgraph-js/1. Basic usage", module)
         const develop = gitgraph.branch("develop").commit("Do something");
         const fix = gitgraph.branch("fix");
         const release = gitgraph.branch("release");
+        const feature = develop.branch("feature");
         fix.commit("Bug fixed.");
 
         release.merge(fix);
+        feature.merge(fix);
         develop.merge(fix, "Bugfixes are always merged back to develop");
 
         master.merge(develop, "New release");

--- a/packages/stories/src/gitgraph-react/1-basic-usage.stories.tsx
+++ b/packages/stories/src/gitgraph-react/1-basic-usage.stories.tsx
@@ -113,9 +113,11 @@ storiesOf("gitgraph-react/1. Basic usage", module)
         const develop = gitgraph.branch("develop").commit("Do something");
         const fix = gitgraph.branch("fix");
         const release = gitgraph.branch("release");
+        const feature = develop.branch("feature");
         fix.commit("Bug fixed.");
 
         release.merge(fix);
+        feature.merge(fix);
         develop.merge(fix, "Bugfixes are always merged back to develop");
 
         master.merge(develop, "New release");


### PR DESCRIPTION
Hello,

I discovered this nice library a few weeks back, and I used it to make a training course on Git workflows in my company. I stumbled across this bug (https://github.com/nicoespeon/gitgraph.js/issues/259) and I spent a little time trying to fix it.

I thought this could interest you, I executed the test suite and it does not seem to break anything. Feel free to merge it or discard it :wink: 

For example :

```
const master = gitgraph.branch("master");
master.commit("Step 1");

const branch1 = gitgraph.branch("branch1");
const branch2 = gitgraph.branch("branch2");
const branch3 = gitgraph.branch("branch3");

branch1.commit("Step 2");
branch2.commit("Step 3");
branch3.commit("Step 4");

master.commit("Step 5");

branch1.merge(master);
branch2.merge(master);
branch3.merge(master);

master.commit("Step 6");
```
![Screenshot_20191117_192117](https://user-images.githubusercontent.com/5741022/69011886-be7b6880-096f-11ea-8e24-f00e4581f9b1.png)
