### PR TITLE
fix undefined current when importing parent branches

### DIFF
--- a/packages/gitgraph-core/src/gitgraph.ts
+++ b/packages/gitgraph-core/src/gitgraph.ts
@@ -340,12 +340,12 @@ class GitgraphCore<TNode = SVGElement> {
         const currentHash = queue.pop() as Commit["hash"];
         const current = this.commits.find(
           ({ hash }) => hash === currentHash,
-        ) as Commit<TNode>;
+        ) as Commit<TNode> | null;
         const prevBranches =
           result.get(currentHash) || new Set<Branch["name"]>();
         prevBranches.add(branch);
         result.set(currentHash, prevBranches);
-        if (current.parents.length > 0) {
+        if (current && current.parents && current.parents.length > 0) {
           queue.push(current.parents[0]);
         }
       }

--- a/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
+++ b/packages/gitgraph-core/src/user-api/gitgraph-user-api.ts
@@ -307,12 +307,12 @@ class GitgraphUserApi<TNode> {
         const currentHash = queue.pop() as Commit["hash"];
         const current = this._graph.commits.find(
           ({ hash }) => hash === currentHash,
-        ) as Commit<TNode>;
+        ) as Commit<TNode> | null;
         const prevBranches =
           result.get(currentHash) || new Set<Branch["name"]>();
         prevBranches.add(branch);
         result.set(currentHash, prevBranches);
-        if (current.parents.length > 0) {
+        if (current && current.parents && current.parents.length > 0) {
           queue.push(current.parents[0]);
         }
       }


### PR DESCRIPTION
Because I want to visualize the commits from only last few days in a huge git repository, I hit an error on current version "cannot get parent of undefined". This should fix it. Never too safe with the nulls.