### PR TITLE
Fixing the parent branch name in readme

### DIFF
--- a/packages/gitgraph-js/README.md
+++ b/packages/gitgraph-js/README.md
@@ -50,10 +50,10 @@ Create an `index.html` file and start coding:
     const master = gitgraph.branch("master");
     master.commit("Initial commit");
 
-    const develop = gitgraph.branch("develop");
+    const develop = master.branch("develop");
     develop.commit("Add TypeScript");
 
-    const aFeature = gitgraph.branch("a-feature");
+    const aFeature = develop.branch("a-feature");
     aFeature
       .commit("Make it work")
       .commit("Make it right")

--- a/packages/gitgraph-node/README.md
+++ b/packages/gitgraph-node/README.md
@@ -34,10 +34,10 @@ const gitgraph = new Gitgraph();
 const master = gitgraph.branch("master");
 master.commit("Set up the project");
 
-const develop = gitgraph.branch("develop");
+const develop = master.branch("develop");
 develop.commit("Add TypeScript");
 
-const aFeature = gitgraph.branch("a-feature");
+const aFeature = develop.branch("a-feature");
 aFeature
   .commit("Make it work")
   .commit("Make it right")

--- a/packages/gitgraph-react/README.md
+++ b/packages/gitgraph-react/README.md
@@ -26,10 +26,10 @@ function MyComponent() {
         const master = gitgraph.branch("master");
         master.commit("Initial commit");
 
-        const develop = gitgraph.branch("develop");
+        const develop = master.branch("develop");
         develop.commit("Add TypeScript");
 
-        const aFeature = gitgraph.branch("a-feature");
+        const aFeature = develop.branch("a-feature");
         aFeature
           .commit("Make it work")
           .commit("Make it right")


### PR DESCRIPTION
There appears to be bug in the intent and code sample included in the documentation, if I understand correctly, the develop branch should be off of master and feature branch should be off of develop. The current doc does not depict this correctly. Submitting the fix for this discrepancy.