### PR TITLE
fix: replace 'transparent' with 'none'

### DIFF
--- a/packages/gitgraph-js/MIGRATE_FROM_GITGRAPH.JS.md
+++ b/packages/gitgraph-js/MIGRATE_FROM_GITGRAPH.JS.md
@@ -234,7 +234,7 @@ For the detailed options signature, things have changed a bit:
 
 ### Removed
 
-- `options.displayTagBox` was used to customize the visibility of the tag box. If `false`, only the tag text is rendered. Now you can customize more elements. Thus, you can achieve the same result with `options.style.bgColor` set to `transparent` and `options.style.strokeWidth` set to `0`.
+- `options.displayTagBox` was used to customize the visibility of the tag box. If `false`, only the tag text is rendered. Now you can customize more elements. Thus, you can achieve the same result with `options.style.bgColor` set to `none` and `options.style.strokeWidth` set to `0`.
 
 ### Added
 

--- a/packages/gitgraph-js/src/gitgraph.ts
+++ b/packages/gitgraph-js/src/gitgraph.ts
@@ -273,7 +273,7 @@ function createGitgraph(
           isBezier,
           gitgraph.isVertical,
         ),
-        fill: "transparent",
+        fill: "none",
         stroke: branch.computedColor || "",
         strokeWidth: branch.style.lineWidth,
         translate: {

--- a/packages/gitgraph-js/src/svg-elements.ts
+++ b/packages/gitgraph-js/src/svg-elements.ts
@@ -178,7 +178,7 @@ function createRect(options: RectOptions): SVGRectElement {
   }
 
   if (options.fill) {
-    rect.setAttribute("fill", options.fill || "transparent");
+    rect.setAttribute("fill", options.fill || "none");
   }
 
   if (options.stroke) {

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -180,7 +180,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
           isBezier,
           this.gitgraph.isVertical,
         )}
-        fill="transparent"
+        fill="none"
         stroke={branch.computedColor}
         strokeWidth={branch.style.lineWidth}
         transform={`translate(${offset}, ${offset})`}


### PR DESCRIPTION
The code contains a couple of references to "transparent" as value for fill. When copying the svg data to file and opening with an SVG editor (for instance, inkscape, but every other converter I tried too) it causes misrendering by using the default black per SVG file standards. Probably because the keyword "transparent" is not supported. "none" seems to yield the same effect and is probably more in line with what you want to express. This PR fixes that.

References: 
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill