### PR TITLE
Fix body of last commit not visible

### DIFF
--- a/packages/gitgraph-js/src/gitgraph.ts
+++ b/packages/gitgraph-js/src/gitgraph.ts
@@ -234,6 +234,7 @@ function createGitgraph(
       // It works… by chance. Technically, we should compute what would
       // *actually* go beyond the computed limits of the graph.
       const horizontalCustomOffset = 50;
+      const verticalCustomOffset = 20;
 
       const widthOffset = gitgraph.isHorizontal
         ? horizontalCustomOffset
@@ -245,7 +246,7 @@ function createGitgraph(
         ? horizontalCustomOffset
         : // Add `TOOLTIP_PADDING` so we don't crop tooltip text
           // Add `BRANCH_LABEL_PADDING_Y` so we don't crop branch label.
-          BRANCH_LABEL_PADDING_Y + TOOLTIP_PADDING;
+          BRANCH_LABEL_PADDING_Y + TOOLTIP_PADDING + verticalCustomOffset;
 
       svg.setAttribute("width", (width + widthOffset).toString());
       svg.setAttribute("height", (height + heightOffset).toString());

--- a/packages/stories/src/gitgraph-js/2-orientations.stories.tsx
+++ b/packages/stories/src/gitgraph-js/2-orientations.stories.tsx
@@ -17,8 +17,13 @@ storiesOf("gitgraph-js/2. Orientations", module)
         const develop = gitgraph.branch("develop");
         develop.commit("one");
         master.commit("two");
+        master.commit({ subject: "Initial commit", body: "Sample body" });
         develop.commit("three");
         master.merge(develop);
+        master.commit({
+          subject: "four",
+          body: "Last commit body",
+        });
       }}
     </GraphContainer>
   ))


### PR DESCRIPTION
When a body is present in the last commit, the vertical svg size
is not big enough to render the message inside the image area

Closes #374