### PR TITLE
[React] Individual file breakout

### DIFF
--- a/packages/gitgraph-react/src/Arrow.tsx
+++ b/packages/gitgraph-react/src/Arrow.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { ReactSvgElement } from "./types";
+import {
+  GitgraphCore,
+  Commit,
+  arrowSvgPath,
+} from "@gitgraph/core";
+
+interface ArrowProps {
+  commits: Array<Commit<ReactSvgElement>>;
+  commit: Commit<ReactSvgElement>;
+  gitgraph: GitgraphCore<ReactSvgElement>;
+  parentHash: string;
+  commitRadius: number;
+}
+
+export class Arrow extends React.Component<ArrowProps> {
+  public render() {
+    const parent = this.props.commits.find(({ hash }) => hash === this.props.parentHash);
+    if (!parent) return null;
+
+    // Starting point, relative to commit
+    const origin = this.props.gitgraph.reverseArrow
+      ? {
+        x: this.props.commitRadius + (parent.x - this.props.commit.x),
+        y: this.props.commitRadius + (parent.y - this.props.commit.y),
+      }
+      : { x: this.props.commitRadius, y: this.props.commitRadius };
+
+    return (
+      <g transform={`translate(${origin.x}, ${origin.y})`}>
+        <path
+          d={arrowSvgPath(this.props.gitgraph, parent, this.props.commit)}
+          fill={this.props.gitgraph.template.arrow.color!}
+        />
+      </g>
+    );
+  }
+}

--- a/packages/gitgraph-react/src/BranchLabel.tsx
+++ b/packages/gitgraph-react/src/BranchLabel.tsx
@@ -76,7 +76,7 @@ export class BranchLabel extends React.Component<BranchLabelProps> {
 
     if (this.props.gitgraph.isVertical) {
       return (
-        <g key={branch.name} ref={ref}>
+        <g ref={ref}>
           {branchLabel}
         </g>
       );
@@ -87,7 +87,6 @@ export class BranchLabel extends React.Component<BranchLabelProps> {
 
       return (
         <g
-          key={branch.name}
           ref={ref}
           transform={`translate(${commit.x}, ${y})`}
         >

--- a/packages/gitgraph-react/src/BranchLabel.tsx
+++ b/packages/gitgraph-react/src/BranchLabel.tsx
@@ -1,55 +1,113 @@
 import * as React from "react";
-import { Branch, Commit } from "@gitgraph/core";
+import { Branch, Commit, GitgraphCore } from "@gitgraph/core";
+import { CommitElement, ReactSvgElement } from "./types";
 
-interface Props {
+interface BranchLabelBaseProps {
   branch: Branch<React.ReactElement<SVGElement>>;
   commit: Commit<React.ReactElement<SVGElement>>;
 }
 
-interface State {
-  textWidth: number;
-  textHeight: number;
+function DefaultBranchLabel({branch, commit}: BranchLabelBaseProps) {
+  const [textSizing, setTextSizing] = React.useState({ textWidth: 0, textHeight: 0 })
+
+  const getSizing = React.useCallback((node) => {
+    const box = node.getBBox();
+    setTextSizing({ textWidth: box.width, textHeight: box.height });
+  }, [])
+
+  const boxWidth = textSizing.textWidth + 2 * BranchLabel.paddingX;
+  const boxHeight = textSizing.textHeight + 2 * BranchLabel.paddingY;
+
+  return (
+    <g>
+      <rect
+        stroke={branch.style.label.strokeColor || commit.style.color}
+        fill={branch.style.label.bgColor}
+        rx={branch.style.label.borderRadius}
+        width={boxWidth}
+        height={boxHeight}
+      />
+      <text
+        ref={getSizing}
+        fill={branch.style.label.color || commit.style.color}
+        style={{ font: branch.style.label.font }}
+        alignmentBaseline="middle"
+        dominantBaseline="middle"
+        x={BranchLabel.paddingX}
+        y={boxHeight / 2}
+      >
+        {branch.name}
+      </text>
+    </g>
+  );
 }
 
-export class BranchLabel extends React.Component<Props, State> {
+interface BranchLabelProps extends BranchLabelBaseProps {
+  gitgraph: GitgraphCore<ReactSvgElement>;
+  initCommitElements: (commit: Commit<ReactSvgElement>) => void;
+  commitsElements: {
+    [commitHash: string]: CommitElement;
+  };
+}
+
+export class BranchLabel extends React.Component<BranchLabelProps> {
   public static readonly paddingX = 10;
   public static readonly paddingY = 5;
-  public readonly state = { textWidth: 0, textHeight: 0 };
-
-  private $text = React.createRef<SVGTextElement>();
-
-  public componentDidMount() {
-    const box = this.$text.current!.getBBox();
-    this.setState({ textWidth: box.width, textHeight: box.height });
-  }
 
   public render() {
-    const { branch, commit } = this.props;
+    const {branch, commit} = this.props;
+    if (!branch.style.label.display) return null;
 
-    const boxWidth = this.state.textWidth + 2 * BranchLabel.paddingX;
-    const boxHeight = this.state.textHeight + 2 * BranchLabel.paddingY;
+    if (!this.props.gitgraph.branchLabelOnEveryCommit) {
+      const commitHash = this.props.gitgraph.refs.getCommit(branch.name);
+      if (commit.hash !== commitHash) return null;
+    }
 
-    return (
-      <g>
-        <rect
-          stroke={branch.style.label.strokeColor || commit.style.color}
-          fill={branch.style.label.bgColor}
-          rx={branch.style.label.borderRadius}
-          width={boxWidth}
-          height={boxHeight}
-        />
-        <text
-          ref={this.$text}
-          fill={branch.style.label.color || commit.style.color}
-          style={{ font: branch.style.label.font }}
-          alignmentBaseline="middle"
-          dominantBaseline="middle"
-          x={BranchLabel.paddingX}
-          y={boxHeight / 2}
-        >
-          {branch.name}
-        </text>
-      </g>
+    // For the moment, we don't handle multiple branch labels.
+    // To do so, we'd need to reposition each of them appropriately.
+    if (commit.branchToDisplay !== branch.name) return null;
+
+    const ref = this.createBranchLabelRef(commit);
+    const branchLabel = branch.renderLabel ? (
+      branch.renderLabel(branch)
+    ) : (
+      <DefaultBranchLabel branch={branch} commit={commit} />
     );
+
+    if (this.props.gitgraph.isVertical) {
+      return (
+        <g key={branch.name} ref={ref}>
+          {branchLabel}
+        </g>
+      );
+    } else {
+      const commitDotSize = commit.style.dot.size * 2;
+      const horizontalMarginTop = 10;
+      const y = commitDotSize + horizontalMarginTop;
+
+      return (
+        <g
+          key={branch.name}
+          ref={ref}
+          transform={`translate(${commit.x}, ${y})`}
+        >
+          {branchLabel}
+        </g>
+      );
+    }
+  }
+
+  private createBranchLabelRef(
+    commit: Commit<ReactSvgElement>,
+  ): React.RefObject<SVGGElement> {
+    const ref = React.createRef<SVGGElement>();
+
+    if (!this.props.commitsElements[commit.hashAbbrev]) {
+      this.props.initCommitElements(commit);
+    }
+
+    this.props.commitsElements[commit.hashAbbrev].branchLabel = ref;
+
+    return ref;
   }
 }

--- a/packages/gitgraph-react/src/BranchPath.tsx
+++ b/packages/gitgraph-react/src/BranchPath.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { toSvgPath, GitgraphCore, Coordinate, Branch } from "@gitgraph/core";
+import { ReactSvgElement } from "./types";
+import { ReactElement } from "react";
+
+interface BranchPathProps {
+  branch: Branch<ReactElement<SVGElement>>;
+  coordinates: Coordinate[][];
+  isBezier: boolean;
+  offset: number;
+  gitgraph: GitgraphCore<ReactSvgElement>;
+  getWithCommitOffset: (props: any) => Coordinate;
+}
+
+export class BranchPath extends React.Component<BranchPathProps, any> {
+  public render() {
+    return (
+      <path
+        key={this.props.branch.name}
+        d={toSvgPath(
+          this.props.coordinates.map((a) => a.map((b) => this.props.getWithCommitOffset(b))),
+          this.props.isBezier,
+          this.props.gitgraph.isVertical,
+        )}
+        fill="none"
+        stroke={this.props.branch.computedColor}
+        strokeWidth={this.props.branch.style.lineWidth}
+        transform={`translate(${this.props.offset}, ${this.props.offset})`}
+      />
+    )
+  }
+}

--- a/packages/gitgraph-react/src/BranchPath.tsx
+++ b/packages/gitgraph-react/src/BranchPath.tsx
@@ -16,7 +16,6 @@ export class BranchPath extends React.Component<BranchPathProps, any> {
   public render() {
     return (
       <path
-        key={this.props.branch.name}
         d={toSvgPath(
           this.props.coordinates.map((a) => a.map((b) => this.props.getWithCommitOffset(b))),
           this.props.isBezier,

--- a/packages/gitgraph-react/src/Commit.tsx
+++ b/packages/gitgraph-react/src/Commit.tsx
@@ -3,7 +3,7 @@ import {
   GitgraphCore,
   Commit,
   Mode,
-  Coordinate
+  Coordinate,
 } from "@gitgraph/core";
 import { CommitElement, ReactSvgElement } from "./types";
 import { Dot } from "./Dot";
@@ -24,6 +24,7 @@ interface CommitsProps {
   };
   getWithCommitOffset: (props: any) => Coordinate;
   setTooltip: (val: React.ReactElement<SVGGElement> | null) => void;
+  setCurrentCommitOver: (val: Commit<ReactSvgElement> | null) => void;
 }
 
 export class CommitComp extends React.Component<CommitsProps, {}> {
@@ -43,7 +44,7 @@ export class CommitComp extends React.Component<CommitsProps, {}> {
           <Tooltip commit={commit}>
             {commit.hashAbbrev} - {commit.subject}
           </Tooltip>
-        </g>
+        </g>,
       );
     }
 
@@ -52,11 +53,11 @@ export class CommitComp extends React.Component<CommitsProps, {}> {
         <Dot
           commit={commit}
           onMouseOver={() => {
-            this.setState({ currentCommitOver: commit });
+            this.props.setCurrentCommitOver(commit);
             commit.onMouseOver();
           }}
           onMouseOut={() => {
-            this.setState({ currentCommitOver: null });
+            this.props.setCurrentCommitOver(null);
             this.props.setTooltip(null);
             commit.onMouseOut();
           }}

--- a/packages/gitgraph-react/src/Commit.tsx
+++ b/packages/gitgraph-react/src/Commit.tsx
@@ -1,0 +1,128 @@
+import * as React from "react";
+import {
+  GitgraphCore,
+  Commit,
+  Mode,
+} from "@gitgraph/core";
+import { CommitElement, ReactSvgElement } from "./types";
+import { Dot } from "./Dot";
+import { Tooltip } from "./Tooltip";
+import { Arrow } from "./Arrow";
+import { Message } from "./Message";
+import { Tag } from "./Tag";
+import { BranchLabel } from "./BranchLabel";
+
+interface CommitsProps {
+  commits: Array<Commit<ReactSvgElement>>;
+  commit: Commit<ReactSvgElement>;
+  currentCommitOver: Commit<ReactSvgElement> | null;
+  gitgraph: GitgraphCore<ReactSvgElement>;
+  initCommitElements: (commit: Commit<ReactSvgElement>) => void;
+  commitsElements: {
+    [commitHash: string]: CommitElement;
+  };
+}
+
+export class CommitComp extends React.Component<CommitsProps, {}> {
+  public render() {
+    const commit = this.props.commit;
+    const { x, y } = this.getWithCommitOffset(commit);
+
+    const shouldRenderTooltip =
+      this.props.currentCommitOver === commit &&
+      (this.props.gitgraph.isHorizontal ||
+        (this.props.gitgraph.mode === Mode.Compact &&
+          commit.style.hasTooltipInCompactMode));
+
+    if (shouldRenderTooltip) {
+      this.$tooltip = (
+        <g key={commit.hashAbbrev} transform={`translate(${x}, ${y})`}>
+          <Tooltip commit={commit}>
+            {commit.hashAbbrev} - {commit.subject}
+          </Tooltip>
+        </g>
+      );
+    }
+
+    return (
+      <g key={commit.hashAbbrev} transform={`translate(${x}, ${y})`}>
+        <Dot
+          commit={commit}
+          onMouseOver={() => {
+            this.setState({ currentCommitOver: commit });
+            commit.onMouseOver();
+          }}
+          onMouseOut={() => {
+            this.setState({ currentCommitOver: null });
+            this.$tooltip = null;
+            commit.onMouseOut();
+          }}
+        />
+        {this.props.gitgraph.template.arrow.size && this.renderArrows(commit)}
+
+        {/* These elements are positionned after component update. */}
+        <g transform={`translate(${-x}, 0)`}>
+          {
+            commit.style.message.display &&
+            <Message
+              commit={commit}
+              commitsElements={this.props.commitsElements}
+              initCommitElements={this.props.initCommitElements}
+            />
+          }
+          {this.renderBranchLabels(commit)}
+          {this.renderTags(commit)}
+        </g>
+      </g>
+    );
+  }
+
+  private renderArrows(commit: Commit<ReactSvgElement>) {
+    const commitRadius = commit.style.dot.size;
+
+    return commit.parents.map((parentHash: string) => {
+      return (
+        <Arrow
+          commits={this.props.commits}
+          commit={commit}
+          gitgraph={this.props.gitgraph}
+          parentHash={parentHash}
+          commitRadius={commitRadius}
+        />
+      );
+    });
+  }
+
+
+  private renderTags(commit: Commit<ReactSvgElement>) {
+    if (!commit.tags) return null;
+    if (this.props.gitgraph.isHorizontal) return null;
+
+    return commit.tags.map((tag) =>
+      <Tag
+        commit={commit}
+        initCommitElements={this.props.initCommitElements}
+        commitsElements={this.props.commitsElements}
+        tag={tag}
+      />,
+    );
+  }
+
+
+  private renderBranchLabels(commit: Commit<ReactSvgElement>) {
+    // @gitgraph/core could compute branch labels into commits directly.
+    // That will make it easier to retrieve them, just like tags.
+    const branches = Array.from(this.props.gitgraph.branches.values());
+    return branches.map((branch) => {
+      return (
+        <BranchLabel
+          gitgraph={this.props.gitgraph}
+          initCommitElements={this.props.initCommitElements}
+          commitsElements={this.props.commitsElements}
+          branch={branch}
+          commit={commit}
+        />
+      );
+    });
+  }
+}

--- a/packages/gitgraph-react/src/Commit.tsx
+++ b/packages/gitgraph-react/src/Commit.tsx
@@ -39,7 +39,7 @@ export class CommitComp extends React.Component<CommitsProps, {}> {
 
     if (shouldRenderTooltip) {
       this.props.setTooltip(
-        <g key={commit.hashAbbrev} transform={`translate(${x}, ${y})`}>
+        <g transform={`translate(${x}, ${y})`}>
           <Tooltip commit={commit}>
             {commit.hashAbbrev} - {commit.subject}
           </Tooltip>
@@ -48,7 +48,7 @@ export class CommitComp extends React.Component<CommitsProps, {}> {
     }
 
     return (
-      <g key={commit.hashAbbrev} transform={`translate(${x}, ${y})`}>
+      <g transform={`translate(${x}, ${y})`}>
         <Dot
           commit={commit}
           onMouseOver={() => {
@@ -86,6 +86,7 @@ export class CommitComp extends React.Component<CommitsProps, {}> {
     return commit.parents.map((parentHash: string) => {
       return (
         <Arrow
+          key={parentHash}
           commits={this.props.commits}
           commit={commit}
           gitgraph={this.props.gitgraph}
@@ -103,6 +104,7 @@ export class CommitComp extends React.Component<CommitsProps, {}> {
 
     return commit.tags.map((tag) =>
       <Tag
+        key={`${commit.hashAbbrev}-${tag.name}`}
         commit={commit}
         initCommitElements={this.props.initCommitElements}
         commitsElements={this.props.commitsElements}
@@ -119,6 +121,7 @@ export class CommitComp extends React.Component<CommitsProps, {}> {
     return branches.map((branch) => {
       return (
         <BranchLabel
+          key={branch.name}
           gitgraph={this.props.gitgraph}
           initCommitElements={this.props.initCommitElements}
           commitsElements={this.props.commitsElements}

--- a/packages/gitgraph-react/src/Commit.tsx
+++ b/packages/gitgraph-react/src/Commit.tsx
@@ -3,6 +3,7 @@ import {
   GitgraphCore,
   Commit,
   Mode,
+  Coordinate
 } from "@gitgraph/core";
 import { CommitElement, ReactSvgElement } from "./types";
 import { Dot } from "./Dot";
@@ -21,12 +22,14 @@ interface CommitsProps {
   commitsElements: {
     [commitHash: string]: CommitElement;
   };
+  getWithCommitOffset: (props: any) => Coordinate;
+  setTooltip: (val: React.ReactElement<SVGGElement> | null) => void;
 }
 
 export class CommitComp extends React.Component<CommitsProps, {}> {
   public render() {
     const commit = this.props.commit;
-    const { x, y } = this.getWithCommitOffset(commit);
+    const { x, y } = this.props.getWithCommitOffset(commit);
 
     const shouldRenderTooltip =
       this.props.currentCommitOver === commit &&
@@ -35,7 +38,7 @@ export class CommitComp extends React.Component<CommitsProps, {}> {
           commit.style.hasTooltipInCompactMode));
 
     if (shouldRenderTooltip) {
-      this.$tooltip = (
+      this.props.setTooltip(
         <g key={commit.hashAbbrev} transform={`translate(${x}, ${y})`}>
           <Tooltip commit={commit}>
             {commit.hashAbbrev} - {commit.subject}
@@ -54,7 +57,7 @@ export class CommitComp extends React.Component<CommitsProps, {}> {
           }}
           onMouseOut={() => {
             this.setState({ currentCommitOver: null });
-            this.$tooltip = null;
+            this.props.setTooltip(null);
             commit.onMouseOut();
           }}
         />

--- a/packages/gitgraph-react/src/Dot.tsx
+++ b/packages/gitgraph-react/src/Dot.tsx
@@ -11,65 +11,71 @@ export const Dot: React.SFC<DotProps> = ({
   commit,
   onMouseOver,
   onMouseOut,
-}) => (
-  /*
-    In order to handle strokes, we need to do some complex stuff here… 😅
+}) => {
+  if (commit.renderDot) {
+    return commit.renderDot(commit);
+  }
 
-    Problem: strokes are drawn inside & outside the circle.
-    But we want the stroke to be drawn inside only!
+  return (
+    /*
+      In order to handle strokes, we need to do some complex stuff here… 😅
 
-    The outside overlaps with other elements, as we expect the dot to have a fixed size. So we want to crop the outside part.
+      Problem: strokes are drawn inside & outside the circle.
+      But we want the stroke to be drawn inside only!
 
-    Solution:
-    1. Create the circle in a <defs>
-    2. Define a clip path that references the circle
-    3. Use the clip path, adding the stroke.
-    4. Double stroke width as half of it will be clipped (the outside part).
+      The outside overlaps with other elements, as we expect the dot to have a fixed size. So we want to crop the outside part.
 
-    Ref.: https://stackoverflow.com/a/32162431/3911841
+      Solution:
+      1. Create the circle in a <defs>
+      2. Define a clip path that references the circle
+      3. Use the clip path, adding the stroke.
+      4. Double stroke width as half of it will be clipped (the outside part).
 
-    P.S. there is a proposal for a stroke-alignment property,
-    but it's still a W3C Draft ¯\_(ツ)_/¯
-    https://svgwg.org/specs/strokes/#SpecifyingStrokeAlignment
-  */
-  <>
-    <defs>
-      <circle
-        id={commit.hash}
-        cx={commit.style.dot.size}
-        cy={commit.style.dot.size}
-        r={commit.style.dot.size}
-        fill={commit.style.dot.color as string}
-      />
-      <clipPath id={`clip-${commit.hash}`}>
-        <use xlinkHref={`#${commit.hash}`} />
-      </clipPath>
-    </defs>
+      Ref.: https://stackoverflow.com/a/32162431/3911841
 
-    <g
-      onClick={commit.onClick}
-      onMouseOver={onMouseOver}
-      onMouseOut={onMouseOut}
-    >
-      <use
-        xlinkHref={`#${commit.hash}`}
-        clipPath={`url(#clip-${commit.hash})`}
-        stroke={commit.style.dot.strokeColor}
-        strokeWidth={
-          commit.style.dot.strokeWidth && commit.style.dot.strokeWidth * 2
-        }
-      />
-      {commit.dotText && (
-        <text
-          alignmentBaseline="central"
-          textAnchor="middle"
-          x={commit.style.dot.size}
-          y={commit.style.dot.size}
-          style={{ font: commit.style.dot.font }}
-        >
-          {commit.dotText}
-        </text>
-      )}
-    </g>
-  </>
-);
+      P.S. there is a proposal for a stroke-alignment property,
+      but it's still a W3C Draft ¯\_(ツ)_/¯
+      https://svgwg.org/specs/strokes/#SpecifyingStrokeAlignment
+    */
+    <>
+      <defs>
+        <circle
+          id={commit.hash}
+          cx={commit.style.dot.size}
+          cy={commit.style.dot.size}
+          r={commit.style.dot.size}
+          fill={commit.style.dot.color as string}
+        />
+        <clipPath id={`clip-${commit.hash}`}>
+          <use xlinkHref={`#${commit.hash}`} />
+        </clipPath>
+      </defs>
+
+      <g
+        onClick={commit.onClick}
+        onMouseOver={onMouseOver}
+        onMouseOut={onMouseOut}
+      >
+        <use
+          xlinkHref={`#${commit.hash}`}
+          clipPath={`url(#clip-${commit.hash})`}
+          stroke={commit.style.dot.strokeColor}
+          strokeWidth={
+            commit.style.dot.strokeWidth && commit.style.dot.strokeWidth * 2
+          }
+        />
+        {commit.dotText && (
+          <text
+            alignmentBaseline="central"
+            textAnchor="middle"
+            x={commit.style.dot.size}
+            y={commit.style.dot.size}
+            style={{ font: commit.style.dot.font }}
+          >
+            {commit.dotText}
+          </text>
+        )}
+      </g>
+    </>
+  );
+};

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -16,7 +16,7 @@ import {
 import { BranchLabel } from "./BranchLabel";
 import { Tooltip } from "./Tooltip";
 import { TAG_PADDING_X } from "./Tag";
-import { CommitElement, ReactSvgElement } from "./types";
+import { CommitElement, ReactSvgElement, CommitOptions, BranchOptions, TagOptions, MergeOptions, Branch } from "./types";
 import { CommitComp } from "./Commit";
 import { BranchPath } from "./BranchPath";
 
@@ -29,6 +29,11 @@ export {
   MergeStyle,
   Mode,
   Orientation,
+  CommitOptions,
+  BranchOptions,
+  TagOptions,
+  MergeOptions,
+  Branch,
 };
 
 type GitgraphProps = GitgraphPropsWithChildren | GitgraphPropsWithGraph;

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -11,14 +11,14 @@ import {
   templateExtend,
   BranchesPaths,
   Coordinate,
-  toSvgPath,
 } from "@gitgraph/core";
 
 import { BranchLabel } from "./BranchLabel";
 import { Tooltip } from "./Tooltip";
-import { Tag, TAG_PADDING_X } from "./Tag";
+import { TAG_PADDING_X } from "./Tag";
 import { CommitElement, ReactSvgElement } from "./types";
 import { CommitComp } from "./Commit";
+import { BranchPath } from "./BranchPath";
 
 export {
   Gitgraph,
@@ -114,6 +114,8 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
                 gitgraph={this.gitgraph}
                 initCommitElements={this.initCommitElements}
                 commitsElements={this.commitsElements}
+                getWithCommitOffset={this.getWithCommitOffset}
+                setTooltip={this.setTooltip}
               />
             )}
           </g>
@@ -157,23 +159,23 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
     });
   }
 
+  private setTooltip(v:  React.ReactElement<SVGGElement> | null) {
+    this.$tooltip = v;
+  }
+
   private renderBranchesPaths() {
     const offset = this.gitgraph.template.commit.dot.size;
     const isBezier =
       this.gitgraph.template.branch.mergeStyle === MergeStyle.Bezier;
     return Array.from(this.state.branchesPaths).map(([branch, coordinates]) => (
-      <path
-        key={branch.name}
-        d={toSvgPath(
-          coordinates.map((a) => a.map((b) => this.getWithCommitOffset(b))),
-          isBezier,
-          this.gitgraph.isVertical,
-        )}
-        fill="none"
-        stroke={branch.computedColor}
-        strokeWidth={branch.style.lineWidth}
-        transform={`translate(${offset}, ${offset})`}
-      />
+        <BranchPath
+          gitgraph={this.gitgraph}
+          branch={branch}
+          coordinates={coordinates}
+          getWithCommitOffset={this.getWithCommitOffset}
+          isBezier={isBezier}
+          offset={offset}
+        />
     ));
   }
 

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -112,6 +112,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
                 commits={this.state.commits}
                 commit={commit}
                 currentCommitOver={this.state.currentCommitOver}
+                setCurrentCommitOver={this.setCurrentCommitOver.bind(this)}
                 gitgraph={this.gitgraph}
                 initCommitElements={this.initCommitElements.bind(this)}
                 commitsElements={this.commitsElements}
@@ -158,6 +159,10 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
       commitYWithOffsets: this.computeOffsets(commits),
       shouldRecomputeOffsets: false,
     });
+  }
+
+  private setCurrentCommitOver(v: Commit<ReactSvgElement> | null) {
+    this.setState({ currentCommitOver: v });
   }
 
   private setTooltip(v:  React.ReactElement<SVGGElement> | null) {

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -108,14 +108,15 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
           <g ref={this.$commits}>
             {this.state.commits.map((commit) =>
               <CommitComp
+                key={commit.hashAbbrev}
                 commits={this.state.commits}
                 commit={commit}
                 currentCommitOver={this.state.currentCommitOver}
                 gitgraph={this.gitgraph}
-                initCommitElements={this.initCommitElements}
+                initCommitElements={this.initCommitElements.bind(this)}
                 commitsElements={this.commitsElements}
-                getWithCommitOffset={this.getWithCommitOffset}
-                setTooltip={this.setTooltip}
+                getWithCommitOffset={this.getWithCommitOffset.bind(this)}
+                setTooltip={this.setTooltip.bind(this)}
               />
             )}
           </g>
@@ -167,12 +168,14 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
     const offset = this.gitgraph.template.commit.dot.size;
     const isBezier =
       this.gitgraph.template.branch.mergeStyle === MergeStyle.Bezier;
+
     return Array.from(this.state.branchesPaths).map(([branch, coordinates]) => (
         <BranchPath
+          key={branch.name}
           gitgraph={this.gitgraph}
           branch={branch}
           coordinates={coordinates}
-          getWithCommitOffset={this.getWithCommitOffset}
+          getWithCommitOffset={this.getWithCommitOffset.bind(this)}
           isBezier={isBezier}
           offset={offset}
         />

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -3,11 +3,6 @@ import {
   GitgraphCore,
   GitgraphOptions,
   GitgraphUserApi,
-  GitgraphCommitOptions,
-  GitgraphBranchOptions,
-  GitgraphTagOptions,
-  GitgraphMergeOptions,
-  BranchUserApi,
   Commit,
   MergeStyle,
   Mode,
@@ -17,31 +12,18 @@ import {
   BranchesPaths,
   Coordinate,
   toSvgPath,
-  arrowSvgPath,
 } from "@gitgraph/core";
 
 import { BranchLabel } from "./BranchLabel";
 import { Tooltip } from "./Tooltip";
-import { Dot } from "./Dot";
 import { Tag, TAG_PADDING_X } from "./Tag";
-
-type ReactSvgElement = React.ReactElement<SVGElement>;
-
-type CommitOptions = GitgraphCommitOptions<ReactSvgElement>;
-type BranchOptions = GitgraphBranchOptions<ReactSvgElement>;
-type TagOptions = GitgraphTagOptions<ReactSvgElement>;
-type MergeOptions = GitgraphMergeOptions<ReactSvgElement>;
-type Branch = BranchUserApi<ReactSvgElement>;
+import { CommitElement, ReactSvgElement } from "./types";
+import { CommitComp } from "./Commit";
 
 export {
   Gitgraph,
   GitgraphProps,
   GitgraphState,
-  CommitOptions,
-  BranchOptions,
-  TagOptions,
-  MergeOptions,
-  Branch,
   TemplateName,
   templateExtend,
   MergeStyle,
@@ -89,11 +71,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
   private $commits = React.createRef<SVGGElement>();
   private $tooltip: React.ReactElement<SVGGElement> | null = null;
   private commitsElements: {
-    [commitHash: string]: {
-      branchLabel: React.RefObject<SVGGElement> | null;
-      tags: Array<React.RefObject<SVGGElement>>;
-      message: React.RefObject<SVGGElement> | null;
-    };
+    [commitHash: string]: CommitElement;
   } = {};
 
   constructor(props: GitgraphProps) {
@@ -127,7 +105,18 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
         {/* Translate graph down => top-most commit tooltip is not cropped */}
         <g transform={`translate(${BranchLabel.paddingX}, ${Tooltip.padding})`}>
           {this.renderBranchesPaths()}
-          {this.renderCommits()}
+          <g ref={this.$commits}>
+            {this.state.commits.map((commit) =>
+              <CommitComp
+                commits={this.state.commits}
+                commit={commit}
+                currentCommitOver={this.state.currentCommitOver}
+                gitgraph={this.gitgraph}
+                initCommitElements={this.initCommitElements}
+                commitsElements={this.commitsElements}
+              />
+            )}
+          </g>
           {this.$tooltip}
         </g>
       </svg>
@@ -186,247 +175,6 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
         transform={`translate(${offset}, ${offset})`}
       />
     ));
-  }
-
-  private renderCommits() {
-    return (
-      <g ref={this.$commits}>
-        {this.state.commits.map((commit) => this.renderCommit(commit))}
-      </g>
-    );
-  }
-
-  private renderCommit(commit: Commit<ReactSvgElement>) {
-    const { x, y } = this.getWithCommitOffset(commit);
-
-    const shouldRenderTooltip =
-      this.state.currentCommitOver === commit &&
-      (this.gitgraph.isHorizontal ||
-        (this.gitgraph.mode === Mode.Compact &&
-          commit.style.hasTooltipInCompactMode));
-
-    if (shouldRenderTooltip) {
-      this.$tooltip = (
-        <g key={commit.hashAbbrev} transform={`translate(${x}, ${y})`}>
-          {this.renderTooltip(commit)}
-        </g>
-      );
-    }
-
-    return (
-      <g key={commit.hashAbbrev} transform={`translate(${x}, ${y})`}>
-        {this.renderDot(commit)}
-        {this.gitgraph.template.arrow.size && this.renderArrows(commit)}
-
-        {/* These elements are positionned after component update. */}
-        <g transform={`translate(${-x}, 0)`}>
-          {commit.style.message.display && this.renderMessage(commit)}
-          {this.renderBranchLabels(commit)}
-          {this.renderTags(commit)}
-        </g>
-      </g>
-    );
-  }
-
-  private renderTooltip(commit: Commit<ReactSvgElement>) {
-    if (commit.renderTooltip) {
-      return commit.renderTooltip(commit);
-    }
-
-    return (
-      <Tooltip commit={commit}>
-        {commit.hashAbbrev} - {commit.subject}
-      </Tooltip>
-    );
-  }
-
-  private renderDot(commit: Commit<ReactSvgElement>) {
-    if (commit.renderDot) {
-      return commit.renderDot(commit);
-    }
-
-    return (
-      <Dot
-        commit={commit}
-        onMouseOver={() => {
-          this.setState({ currentCommitOver: commit });
-          commit.onMouseOver();
-        }}
-        onMouseOut={() => {
-          this.setState({ currentCommitOver: null });
-          this.$tooltip = null;
-          commit.onMouseOut();
-        }}
-      />
-    );
-  }
-
-  private renderArrows(commit: Commit<ReactSvgElement>) {
-    const commitRadius = commit.style.dot.size;
-
-    return commit.parents.map((parentHash) => {
-      const parent = this.state.commits.find(({ hash }) => hash === parentHash);
-      if (!parent) return null;
-
-      // Starting point, relative to commit
-      const origin = this.gitgraph.reverseArrow
-        ? {
-            x: commitRadius + (parent.x - commit.x),
-            y: commitRadius + (parent.y - commit.y),
-          }
-        : { x: commitRadius, y: commitRadius };
-
-      return (
-        <g transform={`translate(${origin.x}, ${origin.y})`}>
-          <path
-            d={arrowSvgPath(this.gitgraph, parent, commit)}
-            fill={this.gitgraph.template.arrow.color!}
-          />
-        </g>
-      );
-    });
-  }
-
-  private renderMessage(commit: Commit<ReactSvgElement>) {
-    const ref = this.createMessageRef(commit);
-
-    if (commit.renderMessage) {
-      return <g ref={ref}>{commit.renderMessage(commit)}</g>;
-    }
-
-    let body = null;
-    if (commit.body) {
-      body = (
-        <foreignObject width="600" x="10">
-          <p>{commit.body}</p>
-        </foreignObject>
-      );
-    }
-
-    // Use commit dot radius to align text with the middle of the dot.
-    const y = commit.style.dot.size;
-
-    return (
-      <g ref={ref} transform={`translate(0, ${y})`}>
-        <text
-          alignmentBaseline="central"
-          fill={commit.style.message.color}
-          style={{ font: commit.style.message.font }}
-          onClick={commit.onMessageClick}
-        >
-          {commit.message}
-        </text>
-        {body}
-      </g>
-    );
-  }
-
-  private renderBranchLabels(commit: Commit<ReactSvgElement>) {
-    // @gitgraph/core could compute branch labels into commits directly.
-    // That will make it easier to retrieve them, just like tags.
-    const branches = Array.from(this.gitgraph.branches.values());
-    return branches.map((branch) => {
-      if (!branch.style.label.display) return null;
-
-      if (!this.gitgraph.branchLabelOnEveryCommit) {
-        const commitHash = this.gitgraph.refs.getCommit(branch.name);
-        if (commit.hash !== commitHash) return null;
-      }
-
-      // For the moment, we don't handle multiple branch labels.
-      // To do so, we'd need to reposition each of them appropriately.
-      if (commit.branchToDisplay !== branch.name) return null;
-
-      const ref = this.createBranchLabelRef(commit);
-      const branchLabel = branch.renderLabel ? (
-        branch.renderLabel(branch)
-      ) : (
-        <BranchLabel branch={branch} commit={commit} />
-      );
-
-      if (this.gitgraph.isVertical) {
-        return (
-          <g key={branch.name} ref={ref}>
-            {branchLabel}
-          </g>
-        );
-      } else {
-        const commitDotSize = commit.style.dot.size * 2;
-        const horizontalMarginTop = 10;
-        const y = commitDotSize + horizontalMarginTop;
-
-        return (
-          <g
-            key={branch.name}
-            ref={ref}
-            transform={`translate(${commit.x}, ${y})`}
-          >
-            {branchLabel}
-          </g>
-        );
-      }
-    });
-  }
-
-  private renderTags(commit: Commit<ReactSvgElement>) {
-    if (!commit.tags) return null;
-    if (this.gitgraph.isHorizontal) return null;
-
-    return commit.tags.map((tag) => {
-      const ref = this.createTagRef(commit);
-
-      return (
-        <g
-          key={`${commit.hashAbbrev}-${tag.name}`}
-          ref={ref}
-          transform={`translate(0, ${commit.style.dot.size})`}
-        >
-          {tag.render ? tag.render(tag.name, tag.style) : <Tag tag={tag} />}
-        </g>
-      );
-    });
-  }
-
-  private createBranchLabelRef(
-    commit: Commit<ReactSvgElement>,
-  ): React.RefObject<SVGGElement> {
-    const ref = React.createRef<SVGGElement>();
-
-    if (!this.commitsElements[commit.hashAbbrev]) {
-      this.initCommitElements(commit);
-    }
-
-    this.commitsElements[commit.hashAbbrev].branchLabel = ref;
-
-    return ref;
-  }
-
-  private createMessageRef(
-    commit: Commit<ReactSvgElement>,
-  ): React.RefObject<SVGGElement> {
-    const ref = React.createRef<SVGGElement>();
-
-    if (!this.commitsElements[commit.hashAbbrev]) {
-      this.initCommitElements(commit);
-    }
-
-    this.commitsElements[commit.hashAbbrev].message = ref;
-
-    return ref;
-  }
-
-  private createTagRef(
-    commit: Commit<ReactSvgElement>,
-  ): React.RefObject<SVGGElement> {
-    const ref = React.createRef<SVGGElement>();
-
-    if (!this.commitsElements[commit.hashAbbrev]) {
-      this.initCommitElements(commit);
-    }
-
-    this.commitsElements[commit.hashAbbrev].tags.push(ref);
-
-    return ref;
   }
 
   private initCommitElements(commit: Commit<ReactSvgElement>): void {

--- a/packages/gitgraph-react/src/Message.tsx
+++ b/packages/gitgraph-react/src/Message.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { CommitElement, ReactSvgElement } from "./types";
+import { Commit } from "../../gitgraph-core/src";
+
+interface MessageProps {
+  commit: Commit<ReactSvgElement>;
+  initCommitElements: (commit: Commit<ReactSvgElement>) => void;
+  commitsElements: {
+    [commitHash: string]: CommitElement;
+  };
+}
+
+export class Message extends React.Component<MessageProps> {
+  public render() {
+    const commit = this.props.commit;
+    const ref = this.createMessageRef(commit);
+
+    if (commit.renderMessage) {
+      return <g ref={ref}>{commit.renderMessage(commit)}</g>;
+    }
+
+    let body = null;
+    if (commit.body) {
+      body = (
+        <foreignObject width="600" x="10">
+          <p>{commit.body}</p>
+        </foreignObject>
+      );
+    }
+
+    // Use commit dot radius to align text with the middle of the dot.
+    const y = commit.style.dot.size;
+
+    return (
+      <g ref={ref} transform={`translate(0, ${y})`}>
+        <text
+          alignmentBaseline="central"
+          fill={commit.style.message.color}
+          style={{ font: commit.style.message.font }}
+          onClick={commit.onMessageClick}
+        >
+          {commit.message}
+        </text>
+        {body}
+      </g>
+    );
+  }
+
+  private createMessageRef(
+    commit: Commit<ReactSvgElement>,
+  ): React.RefObject<SVGGElement> {
+    const ref = React.createRef<SVGGElement>();
+
+    if (!this.props.commitsElements[commit.hashAbbrev]) {
+      this.props.initCommitElements(commit);
+    }
+
+    this.props.commitsElements[commit.hashAbbrev].message = ref;
+
+    return ref;
+  }
+}

--- a/packages/gitgraph-react/src/Message.tsx
+++ b/packages/gitgraph-react/src/Message.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { CommitElement, ReactSvgElement } from "./types";
-import { Commit } from "../../gitgraph-core/src";
+import { Commit } from "@gitgraph/core";
 
 interface MessageProps {
   commit: Commit<ReactSvgElement>;

--- a/packages/gitgraph-react/src/Tag.tsx
+++ b/packages/gitgraph-react/src/Tag.tsx
@@ -1,15 +1,16 @@
 import * as React from "react";
 import { useState, useEffect, useRef } from "react";
-import { Tag as CoreTag } from "@gitgraph/core";
+import { Tag as CoreTag, Commit } from "@gitgraph/core";
+import { CommitElement, ReactSvgElement } from "./types";
 
-interface Props {
+interface BaseTagProps {
   tag: CoreTag<React.ReactElement<SVGElement>>;
 }
 
 export const TAG_PADDING_X = 10;
 export const TAG_PADDING_Y = 5;
 
-export function Tag(props: Props) {
+export function DefaultTag(props: BaseTagProps) {
   const [state, setState] = useState({ textWidth: 0, textHeight: 0 });
   const $text = useRef<SVGTextElement>(null);
 
@@ -57,3 +58,48 @@ export function Tag(props: Props) {
     </g>
   );
 }
+
+interface TagProps extends BaseTagProps {
+  commit: Commit<ReactSvgElement>;
+  initCommitElements: (commit: Commit<ReactSvgElement>) => void;
+  commitsElements: {
+    [commitHash: string]: CommitElement;
+  };
+}
+
+/**
+ * This needs to be refactored into a functional component as well - likely
+ * merged with DefaultTag with an early return instead
+ */
+export class Tag extends React.Component<TagProps> {
+  public render() {
+    const tag = this.props.tag;
+    const commit = this.props.commit;
+    const ref = this.createTagRef(commit);
+
+    return (
+      <g
+        key={`${commit.hashAbbrev}-${tag.name}`}
+        ref={ref}
+        transform={`translate(0, ${commit.style.dot.size})`}
+      >
+        {tag.render ? tag.render(tag.name, tag.style) : <DefaultTag tag={tag} />}
+      </g>
+    );
+  }
+
+  private createTagRef(
+    commit: Commit<ReactSvgElement>,
+  ): React.RefObject<SVGGElement> {
+    const ref = React.createRef<SVGGElement>();
+
+    if (!this.props.commitsElements[commit.hashAbbrev]) {
+      this.props.initCommitElements(commit);
+    }
+
+    this.props.commitsElements[commit.hashAbbrev].tags.push(ref);
+
+    return ref;
+  }
+}
+

--- a/packages/gitgraph-react/src/Tag.tsx
+++ b/packages/gitgraph-react/src/Tag.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useState, useEffect, useRef } from "react";
 import { Tag as CoreTag, Commit } from "@gitgraph/core";
 import { CommitElement, ReactSvgElement } from "./types";
 
@@ -10,11 +9,11 @@ interface BaseTagProps {
 export const TAG_PADDING_X = 10;
 export const TAG_PADDING_Y = 5;
 
-export function DefaultTag(props: BaseTagProps) {
-  const [state, setState] = useState({ textWidth: 0, textHeight: 0 });
-  const $text = useRef<SVGTextElement>(null);
+function DefaultTag(props: BaseTagProps) {
+  const [state, setState] = React.useState({ textWidth: 0, textHeight: 0 });
+  const $text = React.useRef<SVGTextElement>(null);
 
-  useEffect(() => {
+  React.useEffect(() => {
     const box = $text.current!.getBBox();
     setState({ textWidth: box.width, textHeight: box.height });
   }, []);
@@ -79,7 +78,6 @@ export class Tag extends React.Component<TagProps> {
 
     return (
       <g
-        key={`${commit.hashAbbrev}-${tag.name}`}
         ref={ref}
         transform={`translate(0, ${commit.style.dot.size})`}
       >

--- a/packages/gitgraph-react/src/Tooltip.tsx
+++ b/packages/gitgraph-react/src/Tooltip.tsx
@@ -14,6 +14,10 @@ export class Tooltip extends React.Component<
   }
 
   public render() {
+    if (this.props.commit.renderTooltip) {
+      return this.props.commit.renderTooltip(this.props.commit);
+    }
+
     const commitSize = this.props.commit.style.dot.size * 2;
     const offset = 10;
     const padding = Tooltip.padding;

--- a/packages/gitgraph-react/src/types.ts
+++ b/packages/gitgraph-react/src/types.ts
@@ -1,0 +1,22 @@
+import * as React from "react";
+import {
+  GitgraphCommitOptions,
+  GitgraphBranchOptions,
+  GitgraphTagOptions,
+  GitgraphMergeOptions,
+  BranchUserApi,
+} from "@gitgraph/core";
+
+export type ReactSvgElement = React.ReactElement<SVGElement>;
+
+export type CommitOptions = GitgraphCommitOptions<ReactSvgElement>;
+export type BranchOptions = GitgraphBranchOptions<ReactSvgElement>;
+export type TagOptions = GitgraphTagOptions<ReactSvgElement>;
+export type MergeOptions = GitgraphMergeOptions<ReactSvgElement>;
+export type Branch = BranchUserApi<ReactSvgElement>;
+
+export interface CommitElement {
+  branchLabel: React.RefObject<SVGGElement> | null;
+  tags: Array<React.RefObject<SVGGElement>>;
+  message: React.RefObject<SVGGElement> | null;
+}


### PR DESCRIPTION
While investigating the bug #389, I looked in the developer console of React Devtools and found the following:

![before](https://user-images.githubusercontent.com/9100169/99865849-6c13ef80-2b61-11eb-8871-7e2631742548.png)

However, this is not a representative tree of what is being rendered in the `GitGraph.tsx` file. That's because instead of creating new components, we were simply using functions to render the DOM itself. I've broken out the functions into their own files/components, which makes debugging and code maintenance significantly easier:

![after](https://user-images.githubusercontent.com/9100169/99865877-9fef1500-2b61-11eb-8505-ce19af4713dc.png)
 
There's still lots more work to do in terms of refactor effort, but I think this is a step in the right direction. I've tested this in my application and have no discovered any performance or behavior regressions.

I also plan on adding user testing to this library in the near future