### PR TITLE
[React] Fix strict mode label placement

### DIFF
--- a/packages/gitgraph-react/src/BranchLabel.tsx
+++ b/packages/gitgraph-react/src/BranchLabel.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Branch, Commit, GitgraphCore } from "@gitgraph/core";
-import { CommitElement, ReactSvgElement } from "./types";
+import { ReactSvgElement } from "./types";
 
 interface BranchLabelBaseProps {
   branch: Branch<React.ReactElement<SVGElement>>;
@@ -44,69 +44,53 @@ function DefaultBranchLabel({branch, commit}: BranchLabelBaseProps) {
 
 interface BranchLabelProps extends BranchLabelBaseProps {
   gitgraph: GitgraphCore<ReactSvgElement>;
-  initCommitElements: (commit: Commit<ReactSvgElement>) => void;
-  commitsElements: {
-    [commitHash: string]: CommitElement;
-  };
 }
 
-export class BranchLabel extends React.Component<BranchLabelProps> {
-  public static readonly paddingX = 10;
-  public static readonly paddingY = 5;
+export interface CompoundedComponent extends React.ForwardRefExoticComponent<BranchLabelProps> {
+  paddingX: number;
+  paddingY: number;
+}
 
-  public render() {
-    const {branch, commit} = this.props;
-    if (!branch.style.label.display) return null;
+export const BranchLabel = React.forwardRef<SVGGElement, BranchLabelProps>((props, ref) => {
+  const {branch, commit} = props;
+  if (!branch.style.label.display) return null;
 
-    if (!this.props.gitgraph.branchLabelOnEveryCommit) {
-      const commitHash = this.props.gitgraph.refs.getCommit(branch.name);
-      if (commit.hash !== commitHash) return null;
-    }
+  if (!props.gitgraph.branchLabelOnEveryCommit) {
+    const commitHash = props.gitgraph.refs.getCommit(branch.name);
+    if (commit.hash !== commitHash) return null;
+  }
 
-    // For the moment, we don't handle multiple branch labels.
-    // To do so, we'd need to reposition each of them appropriately.
-    if (commit.branchToDisplay !== branch.name) return null;
+  // For the moment, we don't handle multiple branch labels.
+  // To do so, we'd need to reposition each of them appropriately.
+  if (commit.branchToDisplay !== branch.name) return null;
 
-    const ref = this.createBranchLabelRef(commit);
-    const branchLabel = branch.renderLabel ? (
-      branch.renderLabel(branch)
-    ) : (
-      <DefaultBranchLabel branch={branch} commit={commit} />
+  const branchLabel = branch.renderLabel ? (
+    branch.renderLabel(branch)
+  ) : (
+    <DefaultBranchLabel branch={branch} commit={commit} />
+  );
+
+  if (props.gitgraph.isVertical) {
+    return (
+      <g ref={ref}>
+        {branchLabel}
+      </g>
     );
+  } else {
+    const commitDotSize = commit.style.dot.size * 2;
+    const horizontalMarginTop = 10;
+    const y = commitDotSize + horizontalMarginTop;
 
-    if (this.props.gitgraph.isVertical) {
-      return (
-        <g ref={ref}>
-          {branchLabel}
-        </g>
-      );
-    } else {
-      const commitDotSize = commit.style.dot.size * 2;
-      const horizontalMarginTop = 10;
-      const y = commitDotSize + horizontalMarginTop;
-
-      return (
-        <g
-          ref={ref}
-          transform={`translate(${commit.x}, ${y})`}
-        >
-          {branchLabel}
-        </g>
-      );
-    }
+    return (
+      <g
+        ref={ref}
+        transform={`translate(${commit.x}, ${y})`}
+      >
+        {branchLabel}
+      </g>
+    );
   }
+}) as CompoundedComponent;
 
-  private createBranchLabelRef(
-    commit: Commit<ReactSvgElement>,
-  ): React.RefObject<SVGGElement> {
-    const ref = React.createRef<SVGGElement>();
-
-    if (!this.props.commitsElements[commit.hashAbbrev]) {
-      this.props.initCommitElements(commit);
-    }
-
-    this.props.commitsElements[commit.hashAbbrev].branchLabel = ref;
-
-    return ref;
-  }
-}
+BranchLabel.paddingX = 10;
+BranchLabel.paddingY = 5;

--- a/packages/gitgraph-react/src/BranchLabel.tsx
+++ b/packages/gitgraph-react/src/BranchLabel.tsx
@@ -46,6 +46,7 @@ function DefaultBranchLabel({branch, commit}: BranchLabelBaseProps) {
 interface BranchLabelProps extends BranchLabelBaseProps {
   gitgraph: GitgraphCore<ReactSvgElement>;
   ref: MutableRefObject<SVGGElement | undefined>;
+  branchLabelX: number;
 }
 
 export interface CompoundedComponent extends React.ForwardRefExoticComponent<BranchLabelProps> {
@@ -54,7 +55,7 @@ export interface CompoundedComponent extends React.ForwardRefExoticComponent<Bra
 }
 
 export const BranchLabel = React.forwardRef<SVGGElement, BranchLabelProps>((props, ref) => {
-  const {branch, commit} = props;
+  const {branch, commit, branchLabelX} = props;
   if (!branch.style.label.display) return null;
 
   if (!props.gitgraph.branchLabelOnEveryCommit) {
@@ -74,7 +75,7 @@ export const BranchLabel = React.forwardRef<SVGGElement, BranchLabelProps>((prop
 
   if (props.gitgraph.isVertical) {
     return (
-      <g ref={ref}>
+      <g ref={ref} transform={`translate(${branchLabelX || 0}, 0)`}>
         {branchLabel}
       </g>
     );

--- a/packages/gitgraph-react/src/BranchLabel.tsx
+++ b/packages/gitgraph-react/src/BranchLabel.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Branch, Commit, GitgraphCore } from "@gitgraph/core";
 import { ReactSvgElement } from "./types";
+import { MutableRefObject } from "react";
 
 interface BranchLabelBaseProps {
   branch: Branch<React.ReactElement<SVGElement>>;
@@ -44,6 +45,7 @@ function DefaultBranchLabel({branch, commit}: BranchLabelBaseProps) {
 
 interface BranchLabelProps extends BranchLabelBaseProps {
   gitgraph: GitgraphCore<ReactSvgElement>;
+  ref: MutableRefObject<SVGGElement | undefined>;
 }
 
 export interface CompoundedComponent extends React.ForwardRefExoticComponent<BranchLabelProps> {

--- a/packages/gitgraph-react/src/BranchLabel.tsx
+++ b/packages/gitgraph-react/src/BranchLabel.tsx
@@ -12,6 +12,7 @@ function DefaultBranchLabel({branch, commit}: BranchLabelBaseProps) {
   const [textSizing, setTextSizing] = React.useState({ textWidth: 0, textHeight: 0 })
 
   const getSizing = React.useCallback((node) => {
+    if (!node) return;
     const box = node.getBBox();
     setTextSizing({ textWidth: box.width, textHeight: box.height });
   }, [])

--- a/packages/gitgraph-react/src/Commit.tsx
+++ b/packages/gitgraph-react/src/Commit.tsx
@@ -28,8 +28,18 @@ interface CommitsProps {
 export const Commit = (props: CommitsProps) => {
   const {commit, commits, gitgraph, commitMessagesX} = props;
 
-  // This _should_ likely be an array, but is not in order to intentionally keep
-  // a bug in the codebase that existed prior to Hook-ifying this component
+  /**
+   * This _should_ likely be an array, but is not in order to intentionally keep
+   *  a potential bug in the codebase that existed prior to Hook-ifying this component
+   * @see https://github.com/nicoespeon/gitgraph.js/blob/be9cdf45c7f00970e68e1a4ba579ca7f5c672da4/packages/gitgraph-react/src/Gitgraph.tsx#L197
+   * (notice that it's a single `null` value instead of an array
+   *
+   * The potential bug in question is "what happens when there are more than one
+   * branch label rendered? Do they overlap or cause the message X position to be
+   * in the wrong position?"
+   *
+   * TODO: Investigate potential bug outlined above
+   */
   const branchLabelRef = React.useRef<SVGGElement>();
   const tagRefs: MutableRefObject<SVGGElement[]> = React.useRef([]);
   // "as unknown as any" needed to avoid `ref` mistypings later. :(

--- a/packages/gitgraph-react/src/Commit.tsx
+++ b/packages/gitgraph-react/src/Commit.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {
   GitgraphCore,
-  Commit,
+  Commit as CommitCore,
   Mode,
   Coordinate,
 } from "@gitgraph/core";
@@ -15,17 +15,17 @@ import { BranchLabel } from "./BranchLabel";
 import { MutableRefObject } from "react";
 
 interface CommitsProps {
-  commits: Array<Commit<ReactSvgElement>>;
-  commit: Commit<ReactSvgElement>;
-  currentCommitOver: Commit<ReactSvgElement> | null;
+  commits: Array<CommitCore<ReactSvgElement>>;
+  commit: CommitCore<ReactSvgElement>;
+  currentCommitOver: CommitCore<ReactSvgElement> | null;
   gitgraph: GitgraphCore<ReactSvgElement>;
   getWithCommitOffset: (props: any) => Coordinate;
   setTooltip: (val: React.ReactElement<SVGGElement> | null) => void;
-  setCurrentCommitOver: (val: Commit<ReactSvgElement> | null) => void;
+  setCurrentCommitOver: (val: CommitCore<ReactSvgElement> | null) => void;
   commitMessagesX: number;
 }
 
-export const CommitComp = (props: CommitsProps) => {
+export const Commit = (props: CommitsProps) => {
   const {commit, commits, gitgraph, commitMessagesX} = props;
 
   // This _should_ likely be an array, but is not in order to intentionally keep

--- a/packages/gitgraph-react/src/Commit.tsx
+++ b/packages/gitgraph-react/src/Commit.tsx
@@ -5,7 +5,7 @@ import {
   Mode,
   Coordinate,
 } from "@gitgraph/core";
-import { CommitElement, ReactSvgElement } from "./types";
+import { ReactSvgElement } from "./types";
 import { Dot } from "./Dot";
 import { Tooltip } from "./Tooltip";
 import { Arrow } from "./Arrow";
@@ -18,10 +18,6 @@ interface CommitsProps {
   commit: Commit<ReactSvgElement>;
   currentCommitOver: Commit<ReactSvgElement> | null;
   gitgraph: GitgraphCore<ReactSvgElement>;
-  initCommitElements: (commit: Commit<ReactSvgElement>) => void;
-  commitsElements: {
-    [commitHash: string]: CommitElement;
-  };
   getWithCommitOffset: (props: any) => Coordinate;
   setTooltip: (val: React.ReactElement<SVGGElement> | null) => void;
   setCurrentCommitOver: (val: Commit<ReactSvgElement> | null) => void;
@@ -70,8 +66,6 @@ export class CommitComp extends React.Component<CommitsProps, {}> {
             commit.style.message.display &&
             <Message
               commit={commit}
-              commitsElements={this.props.commitsElements}
-              initCommitElements={this.props.initCommitElements}
             />
           }
           {this.renderBranchLabels(commit)}
@@ -107,8 +101,6 @@ export class CommitComp extends React.Component<CommitsProps, {}> {
       <Tag
         key={`${commit.hashAbbrev}-${tag.name}`}
         commit={commit}
-        initCommitElements={this.props.initCommitElements}
-        commitsElements={this.props.commitsElements}
         tag={tag}
       />,
     );
@@ -124,8 +116,6 @@ export class CommitComp extends React.Component<CommitsProps, {}> {
         <BranchLabel
           key={branch.name}
           gitgraph={this.props.gitgraph}
-          initCommitElements={this.props.initCommitElements}
-          commitsElements={this.props.commitsElements}
           branch={branch}
           commit={commit}
         />

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -15,7 +15,6 @@ import {
 
 import { BranchLabel } from "./BranchLabel";
 import { Tooltip } from "./Tooltip";
-import { TAG_PADDING_X } from "./Tag";
 import { ReactSvgElement, CommitOptions, BranchOptions, TagOptions, MergeOptions, Branch } from "./types";
 import { CommitComp } from "./Commit";
 import { BranchPath } from "./BranchPath";
@@ -121,7 +120,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
               />
             )}
           </g>
-          {this.$tooltip}
+          {this.$tooltip}[
         </g>
       </svg>
     );
@@ -197,40 +196,40 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
       return;
     }
 
-    const padding = 10;
+    // const padding = 10;
 
     // Ensure commits elements (branch labels, message…) are well positionned.
     // It can't be done at render time since elements size is dynamic.
-    Object.keys(this.commitsElements).forEach((commitHash) => {
-      const { branchLabel, tags, message } = this.commitsElements[commitHash];
-
-      // We'll store X position progressively and translate elements.
-      let x = this.state.commitMessagesX;
-
-      if (branchLabel && branchLabel.current) {
-        moveElement(branchLabel.current, x);
-
-        // For some reason, one paddingX is missing in BBox width.
-        const branchLabelWidth =
-          branchLabel.current.getBBox().width + BranchLabel.paddingX;
-        x += branchLabelWidth + padding;
-      }
-
-      tags.forEach((tag) => {
-        if (!tag || !tag.current) return;
-
-        moveElement(tag.current, x);
-
-        // For some reason, one paddingX is missing in BBox width.
-        const tagWidth = tag.current.getBBox().width + TAG_PADDING_X;
-        x += tagWidth + padding;
-      });
-
-      if (message && message.current) {
-        // Move message is here
-        moveElement(message.current, x);
-      }
-    });
+    // Object.keys(this.commitsElements).forEach((commitHash) => {
+    //   const { branchLabel, tags, message } = this.commitsElements[commitHash];
+    //
+    //   // We'll store X position progressively and translate elements.
+    //   let x = this.state.commitMessagesX;
+    //
+    //   if (branchLabel && branchLabel.current) {
+    //     moveElement(branchLabel.current, x);
+    //
+    //     // For some reason, one paddingX is missing in BBox width.
+    //     const branchLabelWidth =
+    //       branchLabel.current.getBBox().width + BranchLabel.paddingX;
+    //     x += branchLabelWidth + padding;
+    //   }
+    //
+    //   tags.forEach((tag) => {
+    //     if (!tag || !tag.current) return;
+    //
+    //     moveElement(tag.current, x);
+    //
+    //     // For some reason, one paddingX is missing in BBox width.
+    //     const tagWidth = tag.current.getBBox().width + TAG_PADDING_X;
+    //     x += tagWidth + padding;
+    //   });
+    //
+    //   if (message && message.current) {
+    //     // Move message is here
+    //     moveElement(message.current, x);
+    //   }
+    // });
   }
 
   private computeOffsets(
@@ -292,10 +291,10 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
   }
 }
 
-function moveElement(target: Element, x: number): void {
-  const transform = target.getAttribute("transform") || "translate(0, 0)";
-  target.setAttribute(
-    "transform",
-    transform.replace(/translate\(([\d\.]+),/, `translate(${x},`),
-  );
-}
+// function moveElement(target: Element, x: number): void {
+//   const transform = target.getAttribute("transform") || "translate(0, 0)";
+//   target.setAttribute(
+//     "transform",
+//     transform.replace(/translate\(([\d\.]+),/, `translate(${x},`),
+//   );
+// }

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -3,7 +3,7 @@ import {
   GitgraphCore,
   GitgraphOptions,
   GitgraphUserApi,
-  Commit,
+  Commit as CommitCore,
   MergeStyle,
   Mode,
   Orientation,
@@ -16,7 +16,7 @@ import {
 import { BranchLabel } from "./BranchLabel";
 import { Tooltip } from "./Tooltip";
 import { ReactSvgElement, CommitOptions, BranchOptions, TagOptions, MergeOptions, Branch } from "./types";
-import { CommitComp } from "./Commit";
+import { Commit } from "./Commit";
 import { BranchPath } from "./BranchPath";
 
 export {
@@ -53,7 +53,7 @@ function isPropsWithGraph(
 }
 
 interface GitgraphState {
-  commits: Array<Commit<ReactSvgElement>>;
+  commits: Array<CommitCore<ReactSvgElement>>;
   branchesPaths: BranchesPaths<ReactSvgElement>;
   commitMessagesX: number;
   // Store a map to replace commits y with the correct value,
@@ -62,7 +62,7 @@ interface GitgraphState {
   // Offset should be computed when graph is rendered (componentDidUpdate).
   commitYWithOffsets: { [key: number]: number };
   shouldRecomputeOffsets: boolean;
-  currentCommitOver: Commit<ReactSvgElement> | null;
+  currentCommitOver: CommitCore<ReactSvgElement> | null;
 }
 
 class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
@@ -108,7 +108,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
           {this.renderBranchesPaths()}
           <g ref={this.$commits}>
             {this.state.commits.map((commit) =>
-              <CommitComp
+              <Commit
                 key={commit.hashAbbrev}
                 commits={this.state.commits}
                 commit={commit}
@@ -159,7 +159,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
     });
   }
 
-  private setCurrentCommitOver(v: Commit<ReactSvgElement> | null) {
+  private setCurrentCommitOver(v: CommitCore<ReactSvgElement> | null) {
     this.setState({ currentCommitOver: v });
   }
 

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -117,6 +117,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
                 gitgraph={this.gitgraph}
                 getWithCommitOffset={this.getWithCommitOffset.bind(this)}
                 setTooltip={this.setTooltip.bind(this)}
+                commitMessagesX={this.state.commitMessagesX}
               />
             )}
           </g>
@@ -151,8 +152,6 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
     if (!this.state.shouldRecomputeOffsets) return;
     if (!this.$commits.current) return;
 
-    this.positionCommitsElements();
-
     const commits = Array.from(this.$commits.current.children);
     this.setState({
       commitYWithOffsets: this.computeOffsets(commits),
@@ -184,52 +183,6 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
           offset={offset}
         />
     ));
-  }
-
-  /**
-   * REFACTOR THIS
-   * @private
-   */
-  private positionCommitsElements(): void {
-    if (this.gitgraph.isHorizontal) {
-      // Elements don't appear on horizontal mode, yet.
-      return;
-    }
-
-    // const padding = 10;
-
-    // Ensure commits elements (branch labels, message…) are well positionned.
-    // It can't be done at render time since elements size is dynamic.
-    // Object.keys(this.commitsElements).forEach((commitHash) => {
-    //   const { branchLabel, tags, message } = this.commitsElements[commitHash];
-    //
-    //   // We'll store X position progressively and translate elements.
-    //   let x = this.state.commitMessagesX;
-    //
-    //   if (branchLabel && branchLabel.current) {
-    //     moveElement(branchLabel.current, x);
-    //
-    //     // For some reason, one paddingX is missing in BBox width.
-    //     const branchLabelWidth =
-    //       branchLabel.current.getBBox().width + BranchLabel.paddingX;
-    //     x += branchLabelWidth + padding;
-    //   }
-    //
-    //   tags.forEach((tag) => {
-    //     if (!tag || !tag.current) return;
-    //
-    //     moveElement(tag.current, x);
-    //
-    //     // For some reason, one paddingX is missing in BBox width.
-    //     const tagWidth = tag.current.getBBox().width + TAG_PADDING_X;
-    //     x += tagWidth + padding;
-    //   });
-    //
-    //   if (message && message.current) {
-    //     // Move message is here
-    //     moveElement(message.current, x);
-    //   }
-    // });
   }
 
   private computeOffsets(
@@ -290,11 +243,3 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
     return { x, y: this.state.commitYWithOffsets[y] || y };
   }
 }
-
-// function moveElement(target: Element, x: number): void {
-//   const transform = target.getAttribute("transform") || "translate(0, 0)";
-//   target.setAttribute(
-//     "transform",
-//     transform.replace(/translate\(([\d\.]+),/, `translate(${x},`),
-//   );
-// }

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -16,7 +16,7 @@ import {
 import { BranchLabel } from "./BranchLabel";
 import { Tooltip } from "./Tooltip";
 import { TAG_PADDING_X } from "./Tag";
-import { CommitElement, ReactSvgElement, CommitOptions, BranchOptions, TagOptions, MergeOptions, Branch } from "./types";
+import { ReactSvgElement, CommitOptions, BranchOptions, TagOptions, MergeOptions, Branch } from "./types";
 import { CommitComp } from "./Commit";
 import { BranchPath } from "./BranchPath";
 
@@ -75,9 +75,6 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
   private $graph = React.createRef<SVGSVGElement>();
   private $commits = React.createRef<SVGGElement>();
   private $tooltip: React.ReactElement<SVGGElement> | null = null;
-  private commitsElements: {
-    [commitHash: string]: CommitElement;
-  } = {};
 
   constructor(props: GitgraphProps) {
     super(props);
@@ -119,8 +116,6 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
                 currentCommitOver={this.state.currentCommitOver}
                 setCurrentCommitOver={this.setCurrentCommitOver.bind(this)}
                 gitgraph={this.gitgraph}
-                initCommitElements={this.initCommitElements.bind(this)}
-                commitsElements={this.commitsElements}
                 getWithCommitOffset={this.getWithCommitOffset.bind(this)}
                 setTooltip={this.setTooltip.bind(this)}
               />
@@ -192,14 +187,10 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
     ));
   }
 
-  private initCommitElements(commit: Commit<ReactSvgElement>): void {
-    this.commitsElements[commit.hashAbbrev] = {
-      branchLabel: null,
-      tags: [],
-      message: null,
-    };
-  }
-
+  /**
+   * REFACTOR THIS
+   * @private
+   */
   private positionCommitsElements(): void {
     if (this.gitgraph.isHorizontal) {
       // Elements don't appear on horizontal mode, yet.
@@ -236,6 +227,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
       });
 
       if (message && message.current) {
+        // Move message is here
         moveElement(message.current, x);
       }
     });

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -121,7 +121,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
               />
             )}
           </g>
-          {this.$tooltip}[
+          {this.$tooltip}
         </g>
       </svg>
     );

--- a/packages/gitgraph-react/src/Message.tsx
+++ b/packages/gitgraph-react/src/Message.tsx
@@ -27,8 +27,6 @@ export const Message = React.forwardRef<SVGGElement, MessageProps>((props, ref) 
     const y = commit.style.dot.size;
 
     return (
-      // 0, 14 on buggy
-      // 150, 14 on non-buggy
       <g ref={ref} transform={`translate(${messageX}, ${y})`}>
         <text
           alignmentBaseline="central"

--- a/packages/gitgraph-react/src/Message.tsx
+++ b/packages/gitgraph-react/src/Message.tsx
@@ -11,7 +11,7 @@ export const Message = React.forwardRef<SVGGElement, MessageProps>((props, ref) 
     const {commit, messageX} = props;
 
     if (commit.renderMessage) {
-      return <g ref={ref}>{commit.renderMessage(commit)}</g>;
+      return <g ref={ref}  transform={`translate(${messageX}, 0)`}>{commit.renderMessage(commit)}</g>;
     }
 
     let body = null;

--- a/packages/gitgraph-react/src/Message.tsx
+++ b/packages/gitgraph-react/src/Message.tsx
@@ -1,19 +1,13 @@
 import * as React from 'react';
-import { CommitElement, ReactSvgElement } from "./types";
+import { ReactSvgElement } from "./types";
 import { Commit } from "@gitgraph/core";
 
 interface MessageProps {
   commit: Commit<ReactSvgElement>;
-  initCommitElements: (commit: Commit<ReactSvgElement>) => void;
-  commitsElements: {
-    [commitHash: string]: CommitElement;
-  };
 }
 
-export class Message extends React.Component<MessageProps> {
-  public render() {
-    const commit = this.props.commit;
-    const ref = this.createMessageRef(commit);
+export const Message = React.forwardRef<SVGGElement, MessageProps>((props, ref) => {
+    const commit = props.commit;
 
     if (commit.renderMessage) {
       return <g ref={ref}>{commit.renderMessage(commit)}</g>;
@@ -32,6 +26,8 @@ export class Message extends React.Component<MessageProps> {
     const y = commit.style.dot.size;
 
     return (
+      // 0, 14 on buggy
+      // 150, 14 on non-buggy
       <g ref={ref} transform={`translate(0, ${y})`}>
         <text
           alignmentBaseline="central"
@@ -44,19 +40,4 @@ export class Message extends React.Component<MessageProps> {
         {body}
       </g>
     );
-  }
-
-  private createMessageRef(
-    commit: Commit<ReactSvgElement>,
-  ): React.RefObject<SVGGElement> {
-    const ref = React.createRef<SVGGElement>();
-
-    if (!this.props.commitsElements[commit.hashAbbrev]) {
-      this.props.initCommitElements(commit);
-    }
-
-    this.props.commitsElements[commit.hashAbbrev].message = ref;
-
-    return ref;
-  }
-}
+});

--- a/packages/gitgraph-react/src/Message.tsx
+++ b/packages/gitgraph-react/src/Message.tsx
@@ -4,10 +4,11 @@ import { Commit } from "@gitgraph/core";
 
 interface MessageProps {
   commit: Commit<ReactSvgElement>;
+  messageX: number;
 }
 
 export const Message = React.forwardRef<SVGGElement, MessageProps>((props, ref) => {
-    const commit = props.commit;
+    const {commit, messageX} = props;
 
     if (commit.renderMessage) {
       return <g ref={ref}>{commit.renderMessage(commit)}</g>;
@@ -28,7 +29,7 @@ export const Message = React.forwardRef<SVGGElement, MessageProps>((props, ref) 
     return (
       // 0, 14 on buggy
       // 150, 14 on non-buggy
-      <g ref={ref} transform={`translate(0, ${y})`}>
+      <g ref={ref} transform={`translate(${messageX}, ${y})`}>
         <text
           alignmentBaseline="central"
           fill={commit.style.message.color}

--- a/packages/gitgraph-react/src/Tag.tsx
+++ b/packages/gitgraph-react/src/Tag.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Tag as CoreTag, Commit } from "@gitgraph/core";
-import { CommitElement, ReactSvgElement } from "./types";
+import { ReactSvgElement } from "./types";
 
 interface BaseTagProps {
   tag: CoreTag<React.ReactElement<SVGElement>>;
@@ -60,44 +60,17 @@ function DefaultTag(props: BaseTagProps) {
 
 interface TagProps extends BaseTagProps {
   commit: Commit<ReactSvgElement>;
-  initCommitElements: (commit: Commit<ReactSvgElement>) => void;
-  commitsElements: {
-    [commitHash: string]: CommitElement;
-  };
 }
 
-/**
- * This needs to be refactored into a functional component as well - likely
- * merged with DefaultTag with an early return instead
- */
-export class Tag extends React.Component<TagProps> {
-  public render() {
-    const tag = this.props.tag;
-    const commit = this.props.commit;
-    const ref = this.createTagRef(commit);
+export const Tag = React.forwardRef<SVGGElement, TagProps>((props, ref) => {
+  const {tag, commit} = props;
 
-    return (
-      <g
-        ref={ref}
-        transform={`translate(0, ${commit.style.dot.size})`}
-      >
-        {tag.render ? tag.render(tag.name, tag.style) : <DefaultTag tag={tag} />}
-      </g>
-    );
-  }
-
-  private createTagRef(
-    commit: Commit<ReactSvgElement>,
-  ): React.RefObject<SVGGElement> {
-    const ref = React.createRef<SVGGElement>();
-
-    if (!this.props.commitsElements[commit.hashAbbrev]) {
-      this.props.initCommitElements(commit);
-    }
-
-    this.props.commitsElements[commit.hashAbbrev].tags.push(ref);
-
-    return ref;
-  }
-}
-
+  return (
+    <g
+      ref={ref}
+      transform={`translate(0, ${commit.style.dot.size})`}
+    >
+      {tag.render ? tag.render(tag.name, tag.style) : <DefaultTag tag={tag} />}
+    </g>
+  );
+});

--- a/packages/gitgraph-react/src/Tag.tsx
+++ b/packages/gitgraph-react/src/Tag.tsx
@@ -60,15 +60,16 @@ function DefaultTag(props: BaseTagProps) {
 
 interface TagProps extends BaseTagProps {
   commit: Commit<ReactSvgElement>;
+  tagX: number;
 }
 
 export const Tag = React.forwardRef<SVGGElement, TagProps>((props, ref) => {
-  const {tag, commit} = props;
+  const {tag, commit, tagX} = props;
 
   return (
     <g
       ref={ref}
-      transform={`translate(0, ${commit.style.dot.size})`}
+      transform={`translate(${tagX || 0}, ${commit.style.dot.size})`}
     >
       {tag.render ? tag.render(tag.name, tag.style) : <DefaultTag tag={tag} />}
     </g>

--- a/packages/gitgraph-react/src/types.ts
+++ b/packages/gitgraph-react/src/types.ts
@@ -14,9 +14,3 @@ export type BranchOptions = GitgraphBranchOptions<ReactSvgElement>;
 export type TagOptions = GitgraphTagOptions<ReactSvgElement>;
 export type MergeOptions = GitgraphMergeOptions<ReactSvgElement>;
 export type Branch = BranchUserApi<ReactSvgElement>;
-
-export interface CommitElement {
-  branchLabel: React.RefObject<SVGGElement> | null;
-  tags: Array<React.RefObject<SVGGElement>>;
-  message: React.RefObject<SVGGElement> | null;
-}


### PR DESCRIPTION
This PR builds on top of the work done in #391, it is expected to merge that PR in first.

Fixes #389 

Fixes #367

## Screenshots

Here's the broken version:

![broken](https://user-images.githubusercontent.com/9100169/99868107-6a075c00-2b74-11eb-9f3d-8cea0fa3d65a.png)

Here is it fixed:

![offsetfixed](https://user-images.githubusercontent.com/9100169/99868109-6f64a680-2b74-11eb-9e96-523ef8918a99.png)

## Why did this happen?

React StrictMode disallows and breaks unintended side-effects. The previous method of repositioning the labels was based on a kludgy but clever solution of keeping (homebrewed) `ref`s of every commit inside of a map. Once `componentDidUpdate` ran, it would run through the `ref`s and manually run a side-effect in order to calculate and update the element's `transform` property. This was done using Regex and the DOM APIs

However, that side effect was not very React-like and broke a lot of the timing behaviors, which is why it broke when `StrictMode` was enabled. As such, the solution I took was to assign React `useRef`s on every element during the `Commit` component render. Once `ref`s were assigned, I utilized the `useLayoutEffect` hook (which runs before browser paint, so we don't end up with nodes "jumping") to calculate their width, assign the x-offset values to `useState` hooks, and render those values alongside the actual values

This does a few things for us:

1) It fixes the bug
2) It eliminates "magic" positioning, which displaced the code for X positioning from the code for Y positioning. It is now much easier to follow the positioning code logic
3) Because it consolidates the positioning logic code, it makes these components much more "component-like" and makes further maintenance easier than the previous monolithic system

## Further

This PR is a massive one. I apologize for the breadth of changes in such a little period of time. I've done my best to bugtest, however I wouldn't be surprised if some sneaky buggers got in there. I appreciate the work of the development team to this point and hope this contribution doesn't come off negatively! Huge fan!