### PR TITLE
Fix linting glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "develop": "concurrently npm:watch npm:storybook",
     "website": "lerna run start --scope=@gitgraph/website --stream",
     "deploy:website": "lerna run deploy --scope=@gitgraph/website --stream",
-    "lint": "tslint packages/**/src/**/*",
+    "lint": "tslint packages/*/src/**/*",
     "lint:fix": "npm run lint -- --fix",
     "pretest": "npm run build",
     "test": "jest",


### PR DESCRIPTION
Originally, the linting glob was not only checking the `packages` folders, but all of the subfolders in `packages`. This included `node_modules` and as such, I was getting the following errors on every commit (due to linting being ran thanks to Husky)

```
​C:\Users\crutchcorn\git\OceanBit\graph\gitgraph.js [master ≡ +0 ~1 -0 !]
Î»  npm run lint

> gitgraph.js-monorepo@2.0.0-monorepo lint C:\Users\crutchcorn\git\OceanBit\graph\gitgraph.js
> tslint packages/**/src/**/*


ERROR: packages/gitgraph-js/node_modules/rollup-plugin-commonjs/src/ast-utils.js[50, 76]: == should be ===
ERROR: packages/gitgraph-js/node_modules/rollup-plugin-commonjs/src/index.js[50, 11]: Shadowed name: 'options'
ERROR: packages/gitgraph-js/node_modules/rollup-plugin-commonjs/src/is-cjs.js[10, 4]: The key 'promise' is not sorted alphabetically
ERROR: packages/gitgraph-js/node_modules/rollup-plugin-commonjs/src/transform.js[135, 29]: Shadowed name: 'name'
ERROR: packages/gitgraph-js/node_modules/rollup-plugin-commonjs/src/transform.js[160, 44]: Shadowed name: 'name'
ERROR: packages/gitgraph-js/node_modules/rollup-plugin-commonjs/src/transform.js[277, 13]: Shadowed name: 'name'
ERROR: packages/gitgraph-js/node_modules/rollup-plugin-commonjs/src/transform.js[298, 11]: Shadowed name: 'required'
ERROR: packages/gitgraph-js/node_modules/rollup-plugin-commonjs/src/transform.js[308, 10]: Shadowed name: 'required'
ERROR: packages/gitgraph-js/node_modules/rollup-plugin-commonjs/src/transform.js[377, 14]: Shadowed name: 'name'
ERROR: packages/gitgraph-js/node_modules/rollup-plugin-commonjs/src/transform.js[391, 4]: The key 'name' is not sorted alphabetically
ERROR: packages/gitgraph-js/node_modules/rollup-plugin-commonjs/src/transform.js[409, 4]: The key 'name' is not sorted alphabetically
ERROR: packages/gitgraph-js/node_modules/rollup-plugin-commonjs/src/transform.js[440, 12]: Shadowed name: 'name'
ERROR: packages/gitgraph-js/node_modules/rollup-plugin-commonjs/src/transform.js[455, 8]: The key 'name' is not sorted alphabetically
```

This PR fixes the linting glob and therefore no longer errors on a given commit

My next step in the name of linting this project is to replace TSLint with ESLint, as [TSLint has been depreciated for a year now](https://medium.com/palantir/tslint-in-2019-1a144c2317a9)