### PR TITLE
Branch Deletion

### DIFF
--- a/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.branches.test.ts
+++ b/packages/gitgraph-core/src/__tests__/gitgraph.getRenderedData.branches.test.ts
@@ -221,4 +221,54 @@ describe("Gitgraph.getRenderedData.branches", () => {
       ]);
     });
   });
+
+  describe("deleted branch", () => {
+    let gitgraph;
+
+    let master;
+
+    let develop;
+
+    beforeEach(() => {
+      gitgraph = new GitgraphCore().getUserApi();
+
+      master = gitgraph.branch("master");
+
+      master.commit("one");
+
+      master.commit("two");
+
+      develop = gitgraph.branch("develop");
+
+      develop.commit("three");
+
+      master.checkout();
+    });
+
+    it("should ignore commits on a deleted branch", () => {
+      develop.delete();
+
+      const { commits } = gitgraph._graph.getRenderedData();
+
+      expect(commits).toMatchObject([
+        { subject: "one", refs: [] },
+        { subject: "two", refs: ["master", "HEAD"] },
+      ]);
+    });
+
+    it("should render commits on a deleted branch that was merged before", () => {
+      master.merge(develop);
+
+      develop.delete();
+
+      const { commits } = gitgraph._graph.getRenderedData();
+
+      expect(commits).toMatchObject([
+        { subject: "one", refs: [] },
+        { subject: "two", refs: [] },
+        { subject: "three", refs: [] },
+        { subject: "Merge branch develop", refs: ["master", "HEAD"] },
+      ]);
+    });
+  });
 });

--- a/packages/gitgraph-core/src/refs.ts
+++ b/packages/gitgraph-core/src/refs.ts
@@ -27,6 +27,21 @@ class Refs {
   }
 
   /**
+   * Delete a reference
+   *
+   * @param name Name of the reference
+   */
+  public delete(name: Name): this {
+    if (this.hasName(name)) {
+      this.removeNameFrom(this.getCommit(name)!, name);
+
+      this.commitPerName.delete(name);
+    }
+
+    return this;
+  }
+
+  /**
    * Get the commit hash associated with the given reference name.
    *
    * @param name Name of the ref

--- a/packages/stories/src/gitgraph-js/1-basic-usage.stories.tsx
+++ b/packages/stories/src/gitgraph-js/1-basic-usage.stories.tsx
@@ -389,4 +389,37 @@ storiesOf("gitgraph-js/1. Basic usage", module)
         feat1.commit();
       }}
     </GraphContainer>
+  ))
+  .add("delete a branch", () => (
+    <GraphContainer>
+      {(graphContainer) => {
+        const gitgraph = createGitgraph(graphContainer, {
+          generateCommitHash: createFixedHashGenerator(),
+        });
+
+        const master = gitgraph.branch("master").commit("Initial commit");
+        const develop = gitgraph.branch("develop");
+        develop.commit("one");
+        master.commit("two");
+        master.checkout();
+        develop.delete();
+      }}
+    </GraphContainer>
+  ))
+  .add("delete a branch after merging it", () => (
+    <GraphContainer>
+      {(graphContainer) => {
+        const gitgraph = createGitgraph(graphContainer, {
+          generateCommitHash: createFixedHashGenerator(),
+        });
+
+        const master = gitgraph.branch("master").commit("Initial commit");
+        const develop = gitgraph.branch("develop");
+        develop.commit("one");
+        master.commit("two");
+        master.checkout();
+        master.merge(develop);
+        develop.delete();
+      }}
+    </GraphContainer>
   ));

--- a/packages/stories/src/gitgraph-react/1-basic-usage.stories.tsx
+++ b/packages/stories/src/gitgraph-react/1-basic-usage.stories.tsx
@@ -351,4 +351,29 @@ storiesOf("gitgraph-react/1. Basic usage", module)
         }}
       </Gitgraph>
     );
-  });
+  })
+  .add("delete a branch", () => (
+    <Gitgraph options={{ generateCommitHash: createFixedHashGenerator() }}>
+      {(gitgraph) => {
+        const master = gitgraph.branch("master").commit("Initial commit");
+        const develop = gitgraph.branch("develop");
+        develop.commit("one");
+        master.commit("two");
+        master.checkout();
+        develop.delete();
+      }}
+    </Gitgraph>
+  ))
+  .add("delete a branch after merging it", () => (
+    <Gitgraph options={{ generateCommitHash: createFixedHashGenerator() }}>
+      {(gitgraph) => {
+        const master = gitgraph.branch("master").commit("Initial commit");
+        const develop = gitgraph.branch("develop");
+        develop.commit("one");
+        master.commit("two");
+        master.checkout();
+        master.merge(develop);
+        develop.delete();
+      }}
+    </Gitgraph>
+  ));


### PR DESCRIPTION
This patch adds the possibility to delete a branch. It extends the branch user API so one can call `someBranch.delete()` and see the branch disappear from the rendered graph if it is not merged before.

Concretely, it clears out the branch name from the graph's `branches` property and from its `refs`. Commits and tags from the branch remain in the graph. Once a branch is deleted, the branch user API throws for the operations that don't make sense anymore. It is also impossible to delete a branch when it is checked out.

On the rendering side, only commits that are not reachable somehow disappear from view. This means that if the deleted branch was merged beforehand, the commits stay visible.

To the best of my understanding of the code, this change is compatible with previous use and behavior (notably, all tests pass without update). I also added tests and stories to cover what I added.

Closes #388