### PR TITLE
(@gitgraph/js) Add option to make graph responsive

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "develop": "concurrently npm:watch npm:storybook",
     "website": "lerna run start --scope=@gitgraph/website --stream",
     "deploy:website": "lerna run deploy --scope=@gitgraph/website --stream",
-    "lint": "eslint packages/*/src/**/*.{ts,tsx,js,jsx}",
+    "lint": "eslint packages/**/src/**/*.{ts,tsx}",
     "lint:fix": "npm run lint -- --fix",
     "pretest": "npm run build",
     "test": "jest",

--- a/packages/gitgraph-react/src/Gitgraph.tsx
+++ b/packages/gitgraph-react/src/Gitgraph.tsx
@@ -116,7 +116,7 @@ class Gitgraph extends React.Component<GitgraphProps, GitgraphState> {
           <g ref={this.$commits}>
             {this.state.commits.map((commit) => (
               <Commit
-                key={commit.hashAbbrev}
+                key={commit.hash}
                 commits={this.state.commits}
                 commit={commit}
                 currentCommitOver={this.state.currentCommitOver}

--- a/packages/stories/src/gitgraph-js/1-basic-usage.stories.tsx
+++ b/packages/stories/src/gitgraph-js/1-basic-usage.stories.tsx
@@ -389,4 +389,21 @@ storiesOf("gitgraph-js/1. Basic usage", module)
         feat1.commit();
       }}
     </GraphContainer>
+  ))
+  .add("responsive", () => (
+    <GraphContainer>
+      {(graphContainer) => {
+        const gitgraph = createGitgraph(graphContainer, {
+          generateCommitHash: createFixedHashGenerator(),
+          responsive: true,
+        });
+
+        const master = gitgraph.branch("master").commit("Initial commit");
+        const develop = gitgraph.branch("develop");
+        develop.commit("one");
+        master.commit("two");
+        develop.commit("three");
+        master.merge(develop);
+      }}
+    </GraphContainer>
   ));


### PR DESCRIPTION
Closes #303

Add `responsive` boolean to @gitgraph/js option. Setting it to `true` will make the graph fill the available space of its container.

Usage as following:

```
const gitgraph = createGitgraph(graphContainer, {
  generateCommitHash: createFixedHashGenerator(),
  responsive: true,
});
```

![responsive-gitgraph](https://user-images.githubusercontent.com/1094774/110209002-28b36780-7e58-11eb-9b80-83b1138cde96.gif)

_Note: I also fixed #321 passing by_