### PR TITLE
Fix yarn install

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "gh-pages": "2.0.1",
-    "mdx-deck": "git://github.com/nicoespeon/mdx-deck.git#gitgraphjs-custom-build",
+    "mdx-deck": "https://github.com/nicoespeon/mdx-deck.git#gitgraphjs-custom-build",
     "mdx-deck-code-surfer": "0.5.5",
     "prism-react-renderer": "0.1.6",
     "raw-loader": "0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9221,9 +9221,9 @@ mdx-deck-code-surfer@0.5.5:
     code-surfer "^0.5.5"
     memoize-one "^4.0.2"
 
-"mdx-deck@git://github.com/nicoespeon/mdx-deck.git#gitgraphjs-custom-build":
+"mdx-deck@https://github.com/nicoespeon/mdx-deck.git#gitgraphjs-custom-build":
   version "1.10.2"
-  resolved "git://github.com/nicoespeon/mdx-deck.git#6057b126523f7e8c977be1fd97075916d575b238"
+  resolved "https://github.com/nicoespeon/mdx-deck.git#6057b126523f7e8c977be1fd97075916d575b238"
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/plugin-proposal-class-properties" "^7.0.0"


### PR DESCRIPTION
## The Problem

```bash
$ yarn install
yarn install v1.22.19
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
warning url-loader@1.1.2: Invalid bin field for "url-loader".
warning webpack-hot-client@4.1.1: Invalid bin field for "webpack-hot-client".
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads git://github.com/nicoespeon/mdx-deck.git
Directory: [redacted]/gitgraph.js
Output:
fatal: unable to connect to github.com:
github.com[0: 192.30.255.113]: errno=Operation timed out
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

## Steps to reproduce

In order to reproduce, you must first clean your `yarn` cache, otherwise, the dependency will resolve locally

```bash
git clean -xfd # Deletes installation
npm cache clean
npm cache clean --force
yarn cache clean
yarn cache clean --mirror
```

The actual problem is that GitHub deprecated `git://` as of March 2022. Read more about it here https://blog.readthedocs.com/github-git-protocol-deprecation

Reproduce just that part using

```bash
ls-remote --tags --heads git://github.com/nicoespeon/mdx-deck.git
```

## Workaround 

You can workaround without this patch using the git config command below

```bash
git config --global url."https://".insteadOf git://
```

However, figuring that out and finding the article used 30 minutes of my time, so I hope this PR will save other people.

## Related Work

This change is also part of https://github.com/nicoespeon/gitgraph.js/pull/419

This PR is part of a larger set of changes that are needed in order to build the project reliably. See https://github.com/aicioara-forks/gitgraph.js/pull/1 for a heads-up. I want to clean up that PR and open it up for review in smaller pieces